### PR TITLE
feat: connect router to local agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ This project provides a prototype OpenAI-compatible API that returns a dummy res
 ## Development
 
 Start the router using `make dev` and access `http://localhost:8000/v1/chat/completions`.
+
+For local models, run the Local Agent service:
+
+```bash
+uvicorn local_agent.main:app --port 5000
+```
+
+Any request whose `model` starts with `local` will be forwarded to this agent.

--- a/docs/router_api.md
+++ b/docs/router_api.md
@@ -30,3 +30,13 @@ The response contains a placeholder completion:
   }]
 }
 ```
+
+### Local Agent Forwarding
+
+If the `model` field begins with `local`, the router forwards the request to the Local Agent running on port `5000`:
+
+```bash
+uvicorn local_agent.main:app --port 5000
+```
+
+The router relays the agent's JSON response back to the client.

--- a/local_agent/main.py
+++ b/local_agent/main.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import uuid
+from typing import List, Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="Local Agent")
+
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str
+    messages: List[Message]
+    max_tokens: Optional[int] = None
+    temperature: Optional[float] = None
+    stream: Optional[bool] = False
+
+
+@app.post("/infer")
+async def infer(payload: ChatCompletionRequest):
+    user_msg = payload.messages[-1].content if payload.messages else ""
+    content = f"Echo: {user_msg}"
+    response = {
+        "id": f"local-{uuid.uuid4().hex}",
+        "object": "chat.completion",
+        "created": 0,
+        "model": payload.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        },
+    }
+    return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ license = {text = "MIT"}
 [project.dependencies]
 fastapi = "^0.110"
 uvicorn = {version = "^0.29", extras = ["standard"]}
+httpx = "^0.27"
 
 [build-system]
 requires = ["setuptools"]

--- a/router/main.py
+++ b/router/main.py
@@ -5,11 +5,15 @@ import time
 import uuid
 from typing import List, Optional
 
+import httpx
+from fastapi import HTTPException
+
 from fastapi import FastAPI
 from pydantic import BaseModel
 
 SQLITE_DB_PATH = os.getenv("SQLITE_DB_PATH", "data/models.db")
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+LOCAL_AGENT_URL = os.getenv("LOCAL_AGENT_URL", "http://localhost:5000")
 
 app = FastAPI(title="Intelligent Inference Router")
 
@@ -27,8 +31,21 @@ class ChatCompletionRequest(BaseModel):
     stream: Optional[bool] = False
 
 
+async def forward_to_local_agent(payload: ChatCompletionRequest) -> dict:
+    async with httpx.AsyncClient(base_url=LOCAL_AGENT_URL) as client:
+        resp = await client.post("/infer", json=payload.dict())
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:  # coverage: ignore  -- best-effort
+            raise HTTPException(status_code=502, detail="Local agent error") from exc
+        return resp.json()
+
+
 @app.post("/v1/chat/completions")
 async def chat_completions(payload: ChatCompletionRequest):
+    if payload.model.startswith("local"):
+        return await forward_to_local_agent(payload)
+
     dummy_text = "Hello world"
     response = {
         "id": f"cmpl-{uuid.uuid4().hex}",

--- a/tests/router/test_local_forward.py
+++ b/tests/router/test_local_forward.py
@@ -1,0 +1,23 @@
+import httpx
+from fastapi.testclient import TestClient
+
+import router.main as router_main
+from local_agent.main import app as agent_app
+
+
+def test_forward_to_local_agent(monkeypatch) -> None:
+    monkeypatch.setattr(router_main, "LOCAL_AGENT_URL", "http://testserver")
+
+    def client_factory(*args, **kwargs):
+        return httpx.AsyncClient(app=agent_app, base_url="http://testserver")
+
+    monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
+
+    client = TestClient(router_main.app)
+    payload = {
+        "model": "local_mistral",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    response = client.post("/v1/chat/completions", json=payload)
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "Echo: hi"


### PR DESCRIPTION
## Summary
- forward requests for `local*` models to the Local Agent
- stub Local Agent service with `/infer` endpoint
- document how to run the agent and router
- add unit test for forwarding logic
- add httpx dependency

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*