### PR TITLE
Implement external API proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 .env
 *.py[cod]
 *.egg-info/
+.venv/
 .idea/
 .vscode/
 *.sqlite3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Proxy External API calls via OpenAI provider.

--- a/router/main.py
+++ b/router/main.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import os
 import time
 import uuid
-from typing import List, Optional
+from typing import AsyncIterator, List, Optional
 
 import httpx
 from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -14,6 +15,8 @@ from pydantic import BaseModel
 SQLITE_DB_PATH = os.getenv("SQLITE_DB_PATH", "data/models.db")
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 LOCAL_AGENT_URL = os.getenv("LOCAL_AGENT_URL", "http://localhost:5000")
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "https://api.openai.com")
+EXTERNAL_OPENAI_KEY = os.getenv("EXTERNAL_OPENAI_KEY")
 
 app = FastAPI(title="Intelligent Inference Router")
 
@@ -41,10 +44,55 @@ async def forward_to_local_agent(payload: ChatCompletionRequest) -> dict:
         return resp.json()
 
 
+async def _stream_resp(resp: httpx.Response) -> AsyncIterator[str]:
+    async for chunk in resp.aiter_text():
+        yield chunk
+
+
+async def forward_to_openai(payload: ChatCompletionRequest):
+    """Forward request to the OpenAI API."""
+
+    if EXTERNAL_OPENAI_KEY is None:
+        raise HTTPException(status_code=500, detail="OpenAI key not configured")
+
+    headers = {"Authorization": f"Bearer {EXTERNAL_OPENAI_KEY}"}
+    async with httpx.AsyncClient(base_url=OPENAI_BASE_URL) as client:
+        if payload.stream:
+            resp = await client.post(
+                "/v1/chat/completions",
+                json=payload.dict(),
+                headers=headers,
+                stream=True,
+            )
+            try:
+                resp.raise_for_status()
+            except httpx.HTTPError as exc:  # coverage: ignore  -- best-effort
+                raise HTTPException(
+                    status_code=502, detail="External provider error"
+                ) from exc
+            return StreamingResponse(_stream_resp(resp), media_type="text/event-stream")
+
+        resp = await client.post(
+            "/v1/chat/completions",
+            json=payload.dict(),
+            headers=headers,
+        )
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:  # coverage: ignore  -- best-effort
+            raise HTTPException(
+                status_code=502, detail="External provider error"
+            ) from exc
+        return resp.json()
+
+
 @app.post("/v1/chat/completions")
 async def chat_completions(payload: ChatCompletionRequest):
     if payload.model.startswith("local"):
         return await forward_to_local_agent(payload)
+
+    if payload.model.startswith("gpt-"):
+        return await forward_to_openai(payload)
 
     dummy_text = "Hello world"
     response = {

--- a/tests/router/test_external_proxy.py
+++ b/tests/router/test_external_proxy.py
@@ -1,0 +1,46 @@
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import router.main as router_main
+
+external_app = FastAPI()
+
+
+@external_app.post("/v1/chat/completions")
+async def _completion(payload: router_main.ChatCompletionRequest):
+    user_msg = payload.messages[-1].content if payload.messages else ""
+    content = f"OpenAI: {user_msg}"
+    return {
+        "id": "ext-1",
+        "object": "chat.completion",
+        "created": 0,
+        "model": payload.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
+
+
+def test_forward_to_openai(monkeypatch) -> None:
+    monkeypatch.setattr(router_main, "OPENAI_BASE_URL", "http://testserver")
+    monkeypatch.setattr(router_main, "EXTERNAL_OPENAI_KEY", "dummy")
+
+    def client_factory(*args, **kwargs):
+        return httpx.AsyncClient(app=external_app, base_url="http://testserver")
+
+    monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
+
+    client = TestClient(router_main.app)
+    payload = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    response = client.post("/v1/chat/completions", json=payload)
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "OpenAI: hi"


### PR DESCRIPTION
## Summary
- support calling OpenAI via external proxy in router
- add test for forwarding to OpenAI
- ignore `.venv` directory
- add changelog entry

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*