### PR TITLE
Fix AsyncClient monkeypatch

### DIFF
--- a/tests/router/test_external_proxy.py
+++ b/tests/router/test_external_proxy.py
@@ -31,8 +31,11 @@ def test_forward_to_openai(monkeypatch) -> None:
     monkeypatch.setattr(router_main, "OPENAI_BASE_URL", "http://testserver")
     monkeypatch.setattr(router_main, "EXTERNAL_OPENAI_KEY", "dummy")
 
+    real_async_client = httpx.AsyncClient
+    transport = httpx.ASGITransport(app=external_app)
+
     def client_factory(*args, **kwargs):
-        return httpx.AsyncClient(app=external_app, base_url="http://testserver")
+        return real_async_client(transport=transport, base_url="http://testserver")
 
     monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
 

--- a/tests/router/test_local_forward.py
+++ b/tests/router/test_local_forward.py
@@ -8,8 +8,11 @@ from local_agent.main import app as agent_app
 def test_forward_to_local_agent(monkeypatch) -> None:
     monkeypatch.setattr(router_main, "LOCAL_AGENT_URL", "http://testserver")
 
+    real_async_client = httpx.AsyncClient
+    transport = httpx.ASGITransport(app=agent_app)
+
     def client_factory(*args, **kwargs):
-        return httpx.AsyncClient(app=agent_app, base_url="http://testserver")
+        return real_async_client(transport=transport, base_url="http://testserver")
 
     monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
 


### PR DESCRIPTION
## Summary
- fix local client factory in tests to avoid recursion
- update ASGI client usage for httpx>=0.28

## Testing
- `make test`
