### PR TITLE
Add Docker Compose dev stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment variables for local development
+SQLITE_DB_PATH=data/models.db
+REDIS_URL=redis://redis:6379/0
+LOCAL_AGENT_URL=http://local_agent:5000
+# Base URL for external providers (e.g., OpenAI)
+OPENAI_BASE_URL=https://api.openai.com
+# Replace with your real key
+EXTERNAL_OPENAI_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ __pycache__/
 .coverage
 coverage.xml
 htmlcov/
+data/models.db
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev lint test migrate seed
+.PHONY: dev lint test migrate seed docker-dev
 
 dev:
 	uvicorn router.main:app --reload --port 8000
@@ -16,3 +16,6 @@ migrate:
 
 seed:
 	python -m router.cli seed docs/models_seed.json
+
+docker-dev:
+	docker compose up

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ uvicorn local_agent.main:app --port 5000
 
 Any request whose `model` starts with `local` will be forwarded to this agent.
 
+To run the router, local agent and Redis in Docker containers, use:
+
+```bash
+make docker-dev
+```
+
+Copy `.env.example` to `.env` and adjust the values if needed.
+
 Run the unit tests with coverage enabled using:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  router:
+    image: python:3.10-slim
+    working_dir: /app
+    volumes:
+      - ./:/app
+      - ./data/models.db:/app/data/models.db
+    command: >
+      sh -c "pip install -e . && uvicorn router.main:app --host 0.0.0.0 --port 8000"
+    environment:
+      SQLITE_DB_PATH: /app/data/models.db
+      REDIS_URL: redis://redis:6379/0
+      LOCAL_AGENT_URL: http://local_agent:5000
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com}
+      EXTERNAL_OPENAI_KEY: ${EXTERNAL_OPENAI_KEY}
+    ports:
+      - "8000:8000"
+
+  local_agent:
+    image: python:3.10-slim
+    working_dir: /app
+    volumes:
+      - ./:/app
+    command: >
+      sh -c "pip install -e . && uvicorn local_agent.main:app --host 0.0.0.0 --port 5000"
+    ports:
+      - "5000:5000"
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+volumes: {}


### PR DESCRIPTION
## Summary
- create `docker-compose.yml` with router, local_agent and redis services
- document environment variables in `.env.example`
- add `docker-dev` target to `Makefile`
- document Docker workflow in `README`
- ignore generated SQLite DB

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*