### PR TITLE
Add docker-dev make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-.PHONY: dev lint test migrate seed docs-serve
-.PHONY: dev lint test migrate seed docker-dev
+.PHONY: dev lint test migrate seed docker-dev docs-serve
 
 
 dev:

--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ For local models, run the Local Agent service:
 uvicorn local_agent.main:app --port 5000
 ```
 
+
 Any request whose `model` starts with `local` will be forwarded to this agent.
 
-To run the router, local agent and Redis in Docker containers, use:
+### Docker
+
+To run the router, local agent and Redis using Docker Compose, execute:
 
 ```bash
 make docker-dev


### PR DESCRIPTION
## Summary
- fix `.PHONY` list to include docker-dev
- document Docker Compose workflow in README
- add docker-dev rule for Makefile

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*