### PR TITLE
Update docker-compose and docs

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -14,7 +14,7 @@ This section tracks only the features required for the MVP release. Only items c
 - [x] Provide Local LLM Service via vLLM
 
 ### Shared / Infra
-- [ ] Docker Compose for Dev Stack
+- [x] Docker Compose for Dev Stack
 - [ ] Continuous Integration Workflow
 - [ ] Documentation Site with MkDocs
 

--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,5 @@ docs-serve:
 
 docker-dev:
 	docker compose up
+	docker compose down
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,26 @@ Any request whose `model` starts with `local` will be forwarded to this agent.
 
 ### Docker
 
-To run the router, local agent and Redis using Docker Compose, execute:
+The development stack is defined in `docker-compose.yml` and includes the
+router service and a Redis instance. The SQLite model registry is stored in a
+named volume so data persists between runs.
+
+Start the stack with:
 
 ```bash
 make docker-dev
 ```
 
-Copy `.env.example` to `.env` and adjust the values if needed.
+On macOS you may also run the Local Agent container by enabling the `darwin`
+profile:
+
+```bash
+COMPOSE_PROFILES=darwin make docker-dev
+```
+
+Press `Ctrl+C` to stop the services; the `docker-dev` target will automatically
+remove the containers. Copy `.env.example` to `.env` and adjust the values if
+needed.
 
 Run the unit tests with coverage enabled using:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     working_dir: /app
     volumes:
       - ./:/app
-      - ./data/models.db:/app/data/models.db
+      - sqlite_data:/app/data
     command: >
       sh -c "pip install -e . && uvicorn router.main:app --host 0.0.0.0 --port 8000"
     environment:
@@ -16,6 +16,8 @@ services:
       EXTERNAL_OPENAI_KEY: ${EXTERNAL_OPENAI_KEY}
     ports:
       - "8000:8000"
+    depends_on:
+      - redis
 
   local_agent:
     image: python:3.10-slim
@@ -26,10 +28,13 @@ services:
       sh -c "pip install -e . && uvicorn local_agent.main:app --host 0.0.0.0 --port 5000"
     ports:
       - "5000:5000"
+    profiles:
+      - darwin
 
   redis:
     image: redis:7
     ports:
       - "6379:6379"
 
-volumes: {}
+volumes:
+  sqlite_data:


### PR DESCRIPTION
## Summary
- include named volume and Redis in compose file
- make local_agent optional via `darwin` profile
- auto-clean containers via `docker-dev` target
- document docker-dev usage and update implementation checklist

## Testing
- `make lint`
- `make test` *(fails: 6 errors during collection)*