### PR TITLE
docs: add pages and pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material
+          pip install -e .
+      - name: Build site
+        run: mkdocs build --strict
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./site
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v1
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - SQLite-based model registry with CLI
 - Initial Docker Compose/dev stack setup (in progress)
 - CI workflow (in progress)
-- MkDocs documentation site (in progress)
+- MkDocs documentation site with GitHub Pages
 
 ### Not included in MVP (deferred):
 - Redis caching

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -16,7 +16,7 @@ This section tracks only the features required for the MVP release. Only items c
 ### Shared / Infra
 - [ ] Docker Compose for Dev Stack
 - [ ] Continuous Integration Workflow
-- [ ] Documentation Site with MkDocs
+- [x] Documentation Site with MkDocs
 
 ### Explicitly NOT in MVP
 - [ ] Enable Redis Caching

--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ python -m router.cli refresh-openai
 
 This project uses [MkDocs](https://www.mkdocs.org/) with the
 [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme.
+Key pages include `setup.md`, `usage.md` and `api_examples.md` under `docs/`.
 Start a live preview with:
 
 ```bash
 make docs-serve
 ```
 
-CI builds the site using `mkdocs build` and deploys the generated `site/`
-directory to GitHub Pages.
+CI builds the site using `mkdocs build` and a dedicated workflow deploys the
+generated `site/` directory to GitHub Pages.

--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -1,0 +1,15 @@
+# API Examples
+
+Example request for a dummy completion:
+```bash
+curl -X POST http://localhost:8000/v1/chat/completions \
+     -H 'Content-Type: application/json' \
+     -d '{"model":"dummy","messages":[{"role":"user","content":"hi"}]}'
+```
+
+Example request to the local agent:
+```bash
+curl -X POST http://localhost:8000/v1/chat/completions \
+     -H 'Content-Type: application/json' \
+     -d '{"model":"local_mistral","messages":[{"role":"user","content":"hi"}]}'
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,3 +4,6 @@ Welcome! This site hosts the documentation for the Intelligent Inference Router.
 
 - [Product Requirements](../PRD.md)
 - [Feature Checklist](FEATURES.md)
+- [Setup Guide](setup.md)
+- [Usage](usage.md)
+- [API Examples](api_examples.md)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,21 @@
+# Setup Guide
+
+Follow these steps to prepare a local development environment.
+
+1. Create a Python 3.10 virtual environment and activate it.
+2. Install project dependencies using:
+   ```bash
+   pip install -e .
+   pip install -r requirements-dev.txt
+   ```
+3. Initialize the model registry:
+   ```bash
+   make migrate
+   make seed
+   ```
+4. Start the development server:
+   ```bash
+   make dev
+   ```
+
+See [README](../README.md) for additional details.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,17 @@
+# Usage
+
+The router exposes an OpenAI compatible API at `/v1/chat/completions`.
+
+Start the services locally:
+```bash
+make dev
+```
+
+Then send a completion request:
+```bash
+curl -X POST http://localhost:8000/v1/chat/completions \
+     -H 'Content-Type: application/json' \
+     -d '{"model":"local_mistral","messages":[{"role":"user","content":"hello"}]}'
+```
+
+Requests for models prefixed with `local` are forwarded to the Local Agent.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,18 @@
 site_name: Intelligent Inference Router
+site_url: https://example.github.io/intelligent_inference_router
 docs_dir: docs
 theme:
   name: material
+  language: en
+  palette:
+    scheme: default
+    primary: indigo
+    accent: indigo
+nav:
+  - Home: index.md
+  - Product Requirements: ../PRD.md
+  - Feature Checklist: FEATURES.md
+  - Setup: setup.md
+  - Usage: usage.md
+  - API Examples: api_examples.md
+  - Router API: router_api.md


### PR DESCRIPTION
## Summary
- add setup/usage/API docs
- configure Material theme and nav
- document docs preview and pages workflow
- deploy docs via GitHub Pages
- mark docs site complete in implementation status

## Testing
- `make lint`
- `make test` *(fails: unrecognized arguments --cov)*