### PR TITLE
Implement rate limiting and routing helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ LOCAL_AGENT_URL=http://local_agent:5000
 OPENAI_BASE_URL=https://api.openai.com
 # Replace with your real key
 EXTERNAL_OPENAI_KEY=
+# Rate limiting settings
+RATE_LIMIT_REQUESTS=60
+RATE_LIMIT_WINDOW=60

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -20,7 +20,7 @@ This section tracks only the features required for the MVP release. Only items c
 
 ### Explicitly NOT in MVP
 - [ ] Enable Redis Caching
-- [ ] Rate Limiting
+- [x] Rate Limiting
 - [ ] Smart Routing
 - [ ] Add Request Logging and Metrics
 - [ ] Register Agent with Router

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ make docker-dev
 ```
 
 Copy `.env.example` to `.env` and adjust the values if needed.
+Key environment variables:
+
+- `RATE_LIMIT_REQUESTS` – maximum requests per client within the window
+- `RATE_LIMIT_WINDOW` – window size in seconds for rate limiting
 
 Run the unit tests with coverage enabled using:
 

--- a/tests/router/test_rate_limit.py
+++ b/tests/router/test_rate_limit.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+import router.main as router_main
+
+
+def test_rate_limit(monkeypatch):
+    monkeypatch.setattr(router_main, "RATE_LIMIT_REQUESTS", 2)
+    monkeypatch.setattr(router_main, "RATE_LIMIT_WINDOW", 60)
+    router_main.RATE_LIMIT_STATE.clear()
+    client = TestClient(router_main.app)
+    payload = {"model": "dummy", "messages": [{"role": "user", "content": "hi"}]}
+    assert client.post("/v1/chat/completions", json=payload).status_code == 200
+    assert client.post("/v1/chat/completions", json=payload).status_code == 200
+    resp = client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 429
+    assert resp.json()["detail"] == "Rate limit exceeded"

--- a/tests/router/test_routing_helper.py
+++ b/tests/router/test_routing_helper.py
@@ -1,0 +1,28 @@
+import router.main as router_main
+import router.registry as registry
+from sqlalchemy import create_engine
+
+
+def init_db(tmp_path):
+    db_path = tmp_path / "models.db"
+    router_main.SQLITE_DB_PATH = str(db_path)
+    registry.SQLITE_DB_PATH = str(db_path)
+    registry.engine = create_engine(f"sqlite:///{db_path}")
+    registry.SessionLocal = registry.sessionmaker(bind=registry.engine)
+    registry.create_tables()
+    router_main.load_registry()
+    return db_path
+
+
+def test_select_backend_registry(monkeypatch, tmp_path):
+    init_db(tmp_path)
+    with registry.get_session() as session:
+        registry.upsert_model(session, "gpt-test", "openai", "unused")
+    router_main.load_registry()
+    payload = router_main.ChatCompletionRequest(model="gpt-test", messages=[])
+    assert router_main.select_backend(payload) == "openai"
+
+
+def test_select_backend_prefix():
+    payload = router_main.ChatCompletionRequest(model="local_dummy", messages=[])
+    assert router_main.select_backend(payload) == "local"


### PR DESCRIPTION
## Summary
- enforce per-client rate limits in FastAPI router
- factor backend selection into a helper
- document new rate-limit environment variables
- mark rate limiting as implemented in IMPLEMENTATION_STATUS
- test routing helper and rate limiting

## Testing
- `make lint`
- `make test` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*