### PR TITLE
Implement agent registration heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Local agent forwarding (vllm, Docker-based only)
 - Proxy to OpenAI provider
 - SQLite-based model registry with CLI
+- Agent registration & heartbeat endpoints
 - Initial Docker Compose/dev stack setup (in progress)
 - CI workflow (in progress)
 - MkDocs documentation site (in progress)
@@ -19,7 +20,6 @@
 - Rate limiting
 - Smart routing
 - Request logging and metrics
-- Agent registration & heartbeats
 - llm-d cluster support (Kubernetes, Helm)
 - Additional inference worker types (llm-d)
 - Provider integrations: Anthropic, Google, OpenRouter, Grok, Venice
@@ -31,7 +31,6 @@
 - Rate limiting
 - Smart routing
 - Request logging and metrics
-- Agent registration & heartbeats
 - llm-d cluster support (forwarding, deployment, endpoint exposure)
 - Additional inference worker types (llm-d)
 - Provider integrations: Anthropic, Google, OpenRouter, Grok, Venice

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -23,8 +23,8 @@ This section tracks only the features required for the MVP release. Only items c
 - [ ] Rate Limiting
 - [ ] Smart Routing
 - [ ] Add Request Logging and Metrics
-- [ ] Register Agent with Router
-- [ ] Send Periodic Heartbeats
+- [x] Register Agent with Router
+- [x] Send Periodic Heartbeats
 - [ ] Forward to llm-d Cluster
 - [ ] Deploy llm-d via Helm
 - [ ] Expose Cluster Endpoint to Router

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -34,8 +34,8 @@ These features are required for the MVP milestone. All other features are deferr
 - [ ] Rate Limiting
 - [ ] Smart Routing (intelligent request dispatch)
 - [ ] Add Request Logging and Metrics
-- [ ] Register Agent with Router
-- [ ] Send Periodic Heartbeats
+- [x] Register Agent with Router
+- [x] Send Periodic Heartbeats
 - [ ] Forward to llm-d Cluster
 - [ ] Deploy llm-d via Helm
 - [ ] Expose Cluster Endpoint to Router

--- a/docs/router_api.md
+++ b/docs/router_api.md
@@ -56,6 +56,28 @@ uvicorn local_agent.main:app --port 5000
 
 The router relays the agent's JSON response back to the client.
 
+### Agent Registration & Heartbeats
+
+Agents announce themselves to the router using the `/register` and `/heartbeat`
+endpoints. A registration payload has the form:
+
+```json
+{
+  "name": "local-agent",
+  "endpoint": "http://localhost:5000",
+  "models": ["local_mistral-7b-instruct-q4"]
+}
+```
+
+After registration, agents should periodically `POST` to `/heartbeat` with
+
+```json
+{"name": "local-agent"}
+```
+
+The router stores this data in SQLite and updates the model registry
+accordingly.
+
 ---
 
 ## Post-MVP Roadmap

--- a/local_agent/main.py
+++ b/local_agent/main.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
+import asyncio
+import os
 import uuid
 from typing import List, Optional
+
+import httpx
 
 from fastapi import FastAPI
 from pydantic import BaseModel
 
 app = FastAPI(title="Local Agent")
+
+ROUTER_URL = os.getenv("ROUTER_URL", "http://localhost:8000")
+HEARTBEAT_INTERVAL = int(os.getenv("HEARTBEAT_INTERVAL", "30"))
+AGENT_NAME = os.getenv("AGENT_NAME", "local-agent")
+AGENT_ENDPOINT = os.getenv("AGENT_ENDPOINT", "http://localhost:5000")
+MODEL_LIST = os.getenv("MODEL_LIST", "local_mistral-7b-instruct-q4").split(",")
 
 
 class Message(BaseModel):
@@ -20,6 +30,41 @@ class ChatCompletionRequest(BaseModel):
     max_tokens: Optional[int] = None
     temperature: Optional[float] = None
     stream: Optional[bool] = False
+
+
+async def _post_with_retry(path: str, payload: dict) -> None:
+    """POST data to the router with retry on failure."""
+
+    url = f"{ROUTER_URL.rstrip('/')}{path}"
+    while True:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(url, json=payload)
+                resp.raise_for_status()
+            break
+        except httpx.HTTPError:
+            await asyncio.sleep(1)
+
+
+async def register_with_router() -> None:
+    payload = {
+        "name": AGENT_NAME,
+        "endpoint": AGENT_ENDPOINT,
+        "models": MODEL_LIST,
+    }
+    await _post_with_retry("/register", payload)
+
+
+async def heartbeat_loop() -> None:
+    while True:
+        await _post_with_retry("/heartbeat", {"name": AGENT_NAME})
+        await asyncio.sleep(HEARTBEAT_INTERVAL)
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    asyncio.create_task(register_with_router())
+    asyncio.create_task(heartbeat_loop())
 
 
 @app.post("/infer")

--- a/router/main.py
+++ b/router/main.py
@@ -12,7 +12,14 @@ from fastapi.responses import StreamingResponse
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from .registry import ModelEntry, create_tables, get_session
+from .registry import (
+    ModelEntry,
+    create_tables,
+    get_session,
+    upsert_agent,
+    upsert_model,
+    update_heartbeat,
+)
 
 SQLITE_DB_PATH = os.getenv("SQLITE_DB_PATH", "data/models.db")
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
@@ -51,6 +58,16 @@ class ChatCompletionRequest(BaseModel):
     max_tokens: Optional[int] = None
     temperature: Optional[float] = None
     stream: Optional[bool] = False
+
+
+class AgentRegistration(BaseModel):
+    name: str
+    endpoint: str
+    models: List[str]
+
+
+class AgentHeartbeat(BaseModel):
+    name: str
 
 
 async def forward_to_local_agent(payload: ChatCompletionRequest) -> dict:
@@ -103,6 +120,27 @@ async def forward_to_openai(payload: ChatCompletionRequest):
                 status_code=502, detail="External provider error"
             ) from exc
         return resp.json()
+
+
+@app.post("/register")
+async def register_agent(payload: AgentRegistration) -> dict:
+    """Register a local agent and update the model registry."""
+
+    with get_session() as session:
+        upsert_agent(session, payload.name, payload.endpoint, payload.models)
+        for model in payload.models:
+            upsert_model(session, model, "local", payload.endpoint)
+    load_registry()
+    return {"status": "ok"}
+
+
+@app.post("/heartbeat")
+async def heartbeat(payload: AgentHeartbeat) -> dict:
+    """Update agent heartbeat timestamp."""
+
+    with get_session() as session:
+        update_heartbeat(session, payload.name)
+    return {"status": "ok"}
 
 
 @app.post("/v1/chat/completions")

--- a/router/registry.py
+++ b/router/registry.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import os
 from typing import List
 
-from sqlalchemy import Integer, String, create_engine
+import time
+from sqlalchemy import Float, Integer, String, create_engine
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
@@ -34,6 +35,18 @@ class ModelEntry(Base):  # type: ignore[misc]
     endpoint: Mapped[str] = mapped_column(String, nullable=False)
 
 
+class AgentEntry(Base):  # type: ignore[misc]
+    """ORM model for registered agents."""
+
+    __tablename__ = "agents"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    endpoint: Mapped[str] = mapped_column(String, nullable=False)
+    models: Mapped[str] = mapped_column(String, nullable=False)
+    last_heartbeat: Mapped[float] = mapped_column(Float, nullable=False)
+
+
 def create_tables() -> None:
     """Create registry tables if they do not exist."""
 
@@ -50,6 +63,35 @@ def list_models(session: Session) -> List[ModelEntry]:
     """Return all model entries."""
 
     return session.query(ModelEntry).all()
+
+
+def upsert_agent(session: Session, name: str, endpoint: str, models: List[str]) -> None:
+    """Insert or update an agent entry."""
+
+    now = time.time()
+    agent = session.query(AgentEntry).filter_by(name=name).first()
+    if agent is None:
+        agent = AgentEntry(
+            name=name,
+            endpoint=endpoint,
+            models=",".join(models),
+            last_heartbeat=now,
+        )
+        session.add(agent)
+    else:
+        agent.endpoint = endpoint
+        agent.models = ",".join(models)
+        agent.last_heartbeat = now
+    session.commit()
+
+
+def update_heartbeat(session: Session, name: str) -> None:
+    """Update an agent's heartbeat timestamp."""
+
+    agent = session.query(AgentEntry).filter_by(name=name).first()
+    if agent is not None:
+        agent.last_heartbeat = time.time()
+        session.commit()
 
 
 def upsert_model(session: Session, name: str, type: str, endpoint: str) -> None:
@@ -70,3 +112,9 @@ def clear_models(session: Session) -> None:
 
     session.query(ModelEntry).delete()
     session.commit()
+
+
+def list_agents(session: Session) -> List[AgentEntry]:
+    """Return all registered agents."""
+
+    return session.query(AgentEntry).all()

--- a/tests/local_agent/test_registration.py
+++ b/tests/local_agent/test_registration.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+import local_agent.main as agent
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __aenter__(self) -> "DummyClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        pass
+
+    async def post(self, url: str, json: dict) -> httpx.Response:
+        self.calls += 1
+        if self.calls == 1:
+            raise httpx.RequestError("unavailable", request=httpx.Request("POST", url))
+
+        return httpx.Response(200, request=httpx.Request("POST", url))
+
+
+def test_register_retry(monkeypatch) -> None:
+    client = DummyClient()
+    monkeypatch.setattr(agent.httpx, "AsyncClient", lambda *a, **kw: client)
+    original_sleep = asyncio.sleep
+    monkeypatch.setattr(agent.asyncio, "sleep", lambda s: original_sleep(0))
+
+    asyncio.run(agent.register_with_router())
+
+    assert client.calls == 2


### PR DESCRIPTION
## Summary
- register agents with `/register` and accept `/heartbeat`
- update model registry schema for agent info
- let local agent announce itself on startup and send heartbeats
- add retry logic tests for registration
- document agent registration endpoints
- mark feature complete in docs

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError for SQLAlchemy due to missing deps)*