### PR TITLE
Add latency-aware routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,13 @@ seed:
 docs-serve:
 	mkdocs serve -a 0.0.0.0:8001
 
-docker-dev:
 
-\tdocker compose up
+docker-dev:
+	docker compose up
 
 k3s-up:
-\tk3d cluster create llmd --image rancher/k3s:v1.29.4-k3s1 --wait || true
-\thelm upgrade --install llm-d worker_cluster/chart -n llmd --create-namespace
+	k3d cluster create llmd --image rancher/k3s:v1.29.4-k3s1 --wait || true
+	helm upgrade --install llm-d worker_cluster/chart -n llmd --create-namespace
 	docker compose up
 	docker compose down
 

--- a/docs/router_api.md
+++ b/docs/router_api.md
@@ -59,6 +59,16 @@ uvicorn local_agent.main:app --port 5000
 
 The router relays the agent's JSON response back to the client.
 
+### Smart Routing Logic
+
+`/v1/chat/completions` requests are routed based on model type, estimated
+request cost, and recent backend latency metrics. When a `gpt-*` model is
+requested, the router weighs the measured latency of the OpenAI backend against
+the local agent. If the request cost (roughly the combined prompt length)
+exceeds `ROUTER_COST_THRESHOLD`, the request is sent to the local agent to save
+API usage. Otherwise, the backend with the lowest weighted score—computed from
+`ROUTER_COST_WEIGHT` and `ROUTER_LATENCY_WEIGHT`—is selected.
+
 ### Configuration
 
 The router reads API keys for each provider from environment variables. A sample
@@ -78,6 +88,17 @@ EXTERNAL_GROK_KEY=...
 VENICE_BASE_URL=https://api.venice.ai
 EXTERNAL_VENICE_KEY=...
 ```
+
+Routing decisions also depend on a few tuning variables. These may be set as
+environment variables or placed under `[tool.router]` in `pyproject.toml`:
+
+```bash
+ROUTER_COST_WEIGHT=1.0      # weight applied to request cost
+ROUTER_LATENCY_WEIGHT=1.0   # weight applied to measured backend latency
+ROUTER_COST_THRESHOLD=1000  # route locally if cost exceeds this value
+```
+
+If omitted, the router falls back to the values defined in the project config.
 
 Set the relevant keys before starting the server. Models for each provider must
 be added to the registry using `router.cli add-model` or `refresh-openai` for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,8 @@ redis = "^5.0"
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.router]
+cost_weight = 1.0
+latency_weight = 1.0
+cost_threshold = 1000

--- a/router/main.py
+++ b/router/main.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import os
 import time
 import uuid
-
+import tomllib
+from pathlib import Path
 
 
 import httpx
-from fastapi import FastAPI, HTTPException
-from fastapi.responses import Response, StreamingResponse
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import Response, StreamingResponse, JSONResponse
 from prometheus_client import (
     Counter,
     Histogram,
@@ -18,7 +19,7 @@ from prometheus_client import (
 import logging
 from logging.handlers import TimedRotatingFileHandler
 
-from typing import AsyncIterator, List, Optional, Dict
+from typing import List, Dict
 
 import json
 import hashlib
@@ -26,17 +27,12 @@ import hashlib
 import redis.asyncio as redis
 
 
-import httpx
-from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import StreamingResponse, JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 
 from .utils import stream_resp
 
-from fastapi import FastAPI
 from .schemas import ChatCompletionRequest
-from .providers import anthropic, google, openrouter, grok, venice
 
 from pydantic import BaseModel
 
@@ -95,6 +91,7 @@ REQUEST_LATENCY = Histogram(
     "router_request_latency_seconds",
     "Request latency in seconds",
     labelnames=["backend"],
+)
 
 CACHE_TTL = int(os.getenv("CACHE_TTL", "300"))
 
@@ -103,6 +100,25 @@ redis_client = redis.from_url(REDIS_URL)
 RATE_LIMIT_REQUESTS = int(os.getenv("RATE_LIMIT_REQUESTS", "60"))
 RATE_LIMIT_WINDOW = int(os.getenv("RATE_LIMIT_WINDOW", "60"))
 RATE_LIMIT_STATE: Dict[str, List[float]] = {}
+
+# Routing configuration weights
+try:
+    with open(Path(__file__).resolve().parents[1] / "pyproject.toml", "rb") as f:
+        _config = tomllib.load(f).get("tool", {}).get("router", {})
+except Exception:
+    _config = {}
+
+ROUTER_COST_WEIGHT = float(
+    os.getenv("ROUTER_COST_WEIGHT", _config.get("cost_weight", 1.0))
+)
+ROUTER_LATENCY_WEIGHT = float(
+    os.getenv("ROUTER_LATENCY_WEIGHT", _config.get("latency_weight", 1.0))
+)
+ROUTER_COST_THRESHOLD = int(
+    os.getenv("ROUTER_COST_THRESHOLD", _config.get("cost_threshold", 1000))
+)
+
+BACKEND_METRICS: Dict[str, Dict[str, float]] = {}
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
@@ -123,8 +139,6 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         RATE_LIMIT_STATE[client_ip] = timestamps
         response = await call_next(request)
         return response
-
-
 
 
 app = FastAPI(title="Intelligent Inference Router")
@@ -160,22 +174,6 @@ async def _startup() -> None:
     logger.addHandler(stream_handler)
 
 
-
-class Message(BaseModel):
-    role: str
-    content: str
-
-
-class ChatCompletionRequest(BaseModel):
-    model: str
-    messages: List[Message]
-    max_tokens: Optional[int] = None
-    temperature: Optional[float] = None
-    stream: Optional[bool] = False
-
-
-
-
 class AgentRegistration(BaseModel):
     name: str
     endpoint: str
@@ -185,6 +183,7 @@ class AgentRegistration(BaseModel):
 class AgentHeartbeat(BaseModel):
     name: str
 
+
 def select_backend(payload: ChatCompletionRequest) -> str:
     """Return backend key for the given request."""
 
@@ -192,11 +191,21 @@ def select_backend(payload: ChatCompletionRequest) -> str:
     if entry is not None:
         return entry.type
 
+    def _request_cost(req: ChatCompletionRequest) -> int:
+        return sum(len(m.content) for m in req.messages)
+
     if payload.model.startswith("local"):
         return "local"
 
     if payload.model.startswith("gpt-"):
-        return "openai"
+        cost = _request_cost(payload)
+        if cost >= ROUTER_COST_THRESHOLD:
+            return "local"
+        local_lat = BACKEND_METRICS.get("local", {}).get("latency", 0.0)
+        openai_lat = BACKEND_METRICS.get("openai", {}).get("latency", 0.0)
+        local_score = ROUTER_LATENCY_WEIGHT * local_lat
+        openai_score = ROUTER_LATENCY_WEIGHT * openai_lat + ROUTER_COST_WEIGHT * cost
+        return "local" if local_score <= openai_score else "openai"
 
     return "dummy"
 
@@ -207,8 +216,7 @@ def make_cache_key(payload: ChatCompletionRequest) -> str:
     serialized = json.dumps(payload.dict(), sort_keys=True)
     digest = hashlib.sha256(serialized.encode()).hexdigest()
 
-
-
+    return f"chat:{digest}"
 
 
 async def forward_to_local_agent(payload: ChatCompletionRequest) -> dict:
@@ -258,7 +266,6 @@ async def forward_to_openai(payload: ChatCompletionRequest):
         return resp.json()
 
 
-
 async def forward_to_llmd(payload: ChatCompletionRequest):
     """Forward request to the llm-d cluster."""
 
@@ -276,7 +283,7 @@ async def forward_to_llmd(payload: ChatCompletionRequest):
                 resp.raise_for_status()
             except httpx.HTTPError as exc:  # coverage: ignore  -- best-effort
                 raise HTTPException(status_code=502, detail="llm-d error") from exc
-            return StreamingResponse(_stream_resp(resp), media_type="text/event-stream")
+            return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
 
         resp = await client.post("/v1/chat/completions", json=payload.dict())
         try:
@@ -284,6 +291,7 @@ async def forward_to_llmd(payload: ChatCompletionRequest):
         except httpx.HTTPError as exc:  # coverage: ignore  -- best-effort
             raise HTTPException(status_code=502, detail="llm-d error") from exc
         return resp.json()
+
 
 @app.post("/register")
 async def register_agent(payload: AgentRegistration) -> dict:
@@ -304,7 +312,6 @@ async def heartbeat(payload: AgentHeartbeat) -> dict:
     with get_session() as session:
         update_heartbeat(session, payload.name)
     return {"status": "ok"}
-
 
 
 @app.post("/v1/chat/completions")
@@ -356,6 +363,9 @@ async def chat_completions(payload: ChatCompletionRequest):
         latency = time.perf_counter() - start
         REQUEST_COUNTER.labels(backend=backend).inc()
         REQUEST_LATENCY.labels(backend=backend).observe(latency)
+        stat = BACKEND_METRICS.setdefault(backend, {"latency": 0.0, "count": 0})
+        stat["count"] += 1
+        stat["latency"] += (latency - stat["latency"]) / stat["count"]
         if cache_hit:
             CACHE_HIT_COUNTER.labels(model=payload.model).inc()
         logger.info(
@@ -372,94 +382,3 @@ async def metrics() -> Response:
     """Expose Prometheus metrics."""
 
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
-
-
-    backend = select_backend(payload)
-
-    if backend == "local":
-        return await forward_to_local_agent(payload)
-
-    if backend == "openai":
-        return await forward_to_openai(payload)
-
-    cache_key = make_cache_key(payload)
-    if not payload.stream:
-        cached = await redis_client.get(cache_key)
-        if cached:
-            return json.loads(cached)
-
-    entry = MODEL_REGISTRY.get(payload.model)
-
-    if entry is not None:
-        if entry.type == "local":
-            data = await forward_to_local_agent(payload)
-            if not payload.stream:
-                await redis_client.setex(cache_key, CACHE_TTL, json.dumps(data))
-            return data
-        if entry.type == "openai":
-
-            return await forward_to_openai(payload)
-
-        if entry.type == "llm-d":
-            return await forward_to_llmd(payload)
-
-        if entry.type == "anthropic":
-            return await anthropic.forward(
-                payload, ANTHROPIC_BASE_URL, EXTERNAL_ANTHROPIC_KEY
-            )
-        if entry.type == "google":
-            return await google.forward(payload, GOOGLE_BASE_URL, EXTERNAL_GOOGLE_KEY)
-        if entry.type == "openrouter":
-            return await openrouter.forward(
-                payload, OPENROUTER_BASE_URL, EXTERNAL_OPENROUTER_KEY
-            )
-        if entry.type == "grok":
-            return await grok.forward(payload, GROK_BASE_URL, EXTERNAL_GROK_KEY)
-        if entry.type == "venice":
-            return await venice.forward(payload, VENICE_BASE_URL, EXTERNAL_VENICE_KEY)
-
-            data = await forward_to_openai(payload)
-            if not payload.stream:
-                await redis_client.setex(cache_key, CACHE_TTL, json.dumps(data))
-            return data
-
-
-    if payload.model.startswith("local"):
-        data = await forward_to_local_agent(payload)
-        if not payload.stream:
-            await redis_client.setex(cache_key, CACHE_TTL, json.dumps(data))
-        return data
-
-    if payload.model.startswith("gpt-"):
-        data = await forward_to_openai(payload)
-        if not payload.stream:
-            await redis_client.setex(cache_key, CACHE_TTL, json.dumps(data))
-        return data
-
-
-    if payload.model.startswith("llmd-"):
-        return await forward_to_llmd(payload)
-
-    dummy_text = "Hello world"
-    response = {
-        "id": f"cmpl-{uuid.uuid4().hex}",
-        "object": "chat.completion",
-        "created": int(time.time()),
-        "model": payload.model,
-        "choices": [
-            {
-                "index": 0,
-                "message": {"role": "assistant", "content": dummy_text},
-                "finish_reason": "stop",
-            }
-        ],
-        "usage": {
-            "prompt_tokens": 0,
-            "completion_tokens": 0,
-            "total_tokens": 0,
-        },
-    }
-    if not payload.stream:
-        await redis_client.setex(cache_key, CACHE_TTL, json.dumps(response))
-    return response
-

--- a/tests/local_agent/test_main.py
+++ b/tests/local_agent/test_main.py
@@ -1,4 +1,3 @@
-import pytest
 from fastapi.testclient import TestClient
 
 from local_agent.main import app

--- a/tests/router/test_routing_helper.py
+++ b/tests/router/test_routing_helper.py
@@ -26,3 +26,24 @@ def test_select_backend_registry(monkeypatch, tmp_path):
 def test_select_backend_prefix():
     payload = router_main.ChatCompletionRequest(model="local_dummy", messages=[])
     assert router_main.select_backend(payload) == "local"
+
+
+def test_select_backend_cost_threshold(monkeypatch):
+    monkeypatch.setattr(router_main, "ROUTER_COST_THRESHOLD", 5)
+    payload = router_main.ChatCompletionRequest(
+        model="gpt-any",
+        messages=[router_main.Message(role="user", content="x" * 10)],
+    )
+    router_main.BACKEND_METRICS.clear()
+    assert router_main.select_backend(payload) == "local"
+
+
+def test_select_backend_latency(monkeypatch):
+    monkeypatch.setattr(router_main, "ROUTER_COST_THRESHOLD", 100)
+    router_main.BACKEND_METRICS["local"] = {"latency": 2.0, "count": 1}
+    router_main.BACKEND_METRICS["openai"] = {"latency": 0.1, "count": 1}
+    payload = router_main.ChatCompletionRequest(
+        model="gpt-fast",
+        messages=[router_main.Message(role="user", content="hi")],
+    )
+    assert router_main.select_backend(payload) == "openai"


### PR DESCRIPTION
## Summary
- adjust Makefile tabs so `make` works
- tune routing using request cost & latency metrics
- expose routing weights in `pyproject.toml`
- document routing logic and config
- test new selection helper logic

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError due to missing deps)*