### PR TITLE
Add OpenRouter provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ ANTHROPIC_BASE_URL=https://api.anthropic.com
 EXTERNAL_ANTHROPIC_KEY=
 GOOGLE_BASE_URL=https://generativelanguage.googleapis.com
 EXTERNAL_GOOGLE_KEY=
+# Settings for OpenRouter aggregation service
 OPENROUTER_BASE_URL=https://openrouter.ai
 EXTERNAL_OPENROUTER_KEY=
 GROK_BASE_URL=https://api.groq.com

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -60,7 +60,7 @@ This section tracks features, integrations, and improvements to be implemented a
 ## Planned Provider Integrations (Post-MVP)
 - [x] Anthropic
 - Google
-- OpenRouter
+- [x] OpenRouter
 - Grok
 - Venice
 

--- a/docs/router_api.md
+++ b/docs/router_api.md
@@ -79,6 +79,9 @@ VENICE_BASE_URL=https://api.venice.ai
 EXTERNAL_VENICE_KEY=...
 ```
 
+For OpenRouter, both `OPENROUTER_BASE_URL` and `EXTERNAL_OPENROUTER_KEY` must be
+set before the router can forward requests to the service.
+
 Set the relevant keys before starting the server. Models for each provider must
 be added to the registry using `router.cli add-model` or `refresh-openai` for
 OpenAI.

--- a/router/main.py
+++ b/router/main.py
@@ -95,6 +95,7 @@ REQUEST_LATENCY = Histogram(
     "router_request_latency_seconds",
     "Request latency in seconds",
     labelnames=["backend"],
+)
 
 CACHE_TTL = int(os.getenv("CACHE_TTL", "300"))
 

--- a/tests/router/test_provider_openrouter.py
+++ b/tests/router/test_provider_openrouter.py
@@ -1,0 +1,60 @@
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import router.main as router_main
+import router.registry as registry
+from sqlalchemy import create_engine
+
+openrouter_app = FastAPI()
+
+
+@openrouter_app.post("/api/v1/chat/completions")
+async def _completions(payload: router_main.ChatCompletionRequest):
+    user_msg = payload.messages[-1].content if payload.messages else ""
+    content = f"OpenRouter: {user_msg}"
+    return {
+        "id": "or-1",
+        "object": "chat.completion",
+        "created": 0,
+        "model": payload.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
+
+
+def test_forward_to_openrouter(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(router_main, "OPENROUTER_BASE_URL", "http://testserver")
+    monkeypatch.setattr(router_main, "EXTERNAL_OPENROUTER_KEY", "dummy")
+
+    db_path = tmp_path / "models.db"
+    monkeypatch.setattr(router_main, "SQLITE_DB_PATH", str(db_path))
+    registry.SQLITE_DB_PATH = str(db_path)
+    registry.engine = create_engine(f"sqlite:///{db_path}")
+    registry.SessionLocal = registry.sessionmaker(bind=registry.engine)
+    registry.create_tables()
+    with registry.get_session() as session:
+        registry.upsert_model(session, "mixtral-8x7b", "openrouter", "unused")
+
+    real_async_client = httpx.AsyncClient
+    transport = httpx.ASGITransport(app=openrouter_app)
+
+    def client_factory(*args, **kwargs):
+        return real_async_client(transport=transport, base_url="http://testserver")
+
+    monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
+
+    client = TestClient(router_main.app)
+    payload = {
+        "model": "mixtral-8x7b",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    response = client.post("/v1/chat/completions", json=payload)
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "OpenRouter: hi"


### PR DESCRIPTION
## Summary
- close missing parenthesis in router/main
- document OpenRouter variables in docs and `.env.example`
- mark OpenRouter integration in status file
- add unit test for OpenRouter provider

## Testing
- `ruff check .`
- `black --check router/providers/openrouter.py tests/router/test_provider_openrouter.py`
- `mypy router/providers/openrouter.py tests/router/test_provider_openrouter.py` *(fails: Name "ChatCompletionRequest" already defined)*
- `pytest -q` *(fails: 13 errors during collection)*