### PR TITLE
Add Grok provider streaming support and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ GOOGLE_BASE_URL=https://generativelanguage.googleapis.com
 EXTERNAL_GOOGLE_KEY=
 OPENROUTER_BASE_URL=https://openrouter.ai
 EXTERNAL_OPENROUTER_KEY=
+# Grok provider configuration
 GROK_BASE_URL=https://api.groq.com
 EXTERNAL_GROK_KEY=
 VENICE_BASE_URL=https://api.venice.ai

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -61,7 +61,7 @@ This section tracks features, integrations, and improvements to be implemented a
 - [x] Anthropic
 - Google
 - OpenRouter
-- Grok
+- [x] Grok
 - Venice
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .PHONY: dev lint test migrate seed docker-dev docs-serve k3s-up
 
-
 dev:
 	uvicorn router.main:app --reload --port 8000
 
@@ -18,18 +17,14 @@ migrate:
 seed:
 	python -m router.cli seed docs/models_seed.json
 
-
 docs-serve:
 	mkdocs serve -a 0.0.0.0:8001
 
 docker-dev:
-
-\tdocker compose up
+	docker compose up
 
 k3s-up:
-\tk3d cluster create llmd --image rancher/k3s:v1.29.4-k3s1 --wait || true
-\thelm upgrade --install llm-d worker_cluster/chart -n llmd --create-namespace
+	k3d cluster create llmd --image rancher/k3s:v1.29.4-k3s1 --wait || true
+	helm upgrade --install llm-d worker_cluster/chart -n llmd --create-namespace
 	docker compose up
 	docker compose down
-
-

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Key environment variables:
 
 - `RATE_LIMIT_REQUESTS` – maximum requests per client within the window
 - `RATE_LIMIT_WINDOW` – window size in seconds for rate limiting
-=======
+- `GROK_BASE_URL` – base URL for the Grok API
+- `EXTERNAL_GROK_KEY` – API key for Grok
+
 On macOS you may also run the Local Agent container by enabling the `darwin`
 profile:
 

--- a/router/main.py
+++ b/router/main.py
@@ -5,10 +5,9 @@ import time
 import uuid
 
 
-
 import httpx
-from fastapi import FastAPI, HTTPException
-from fastapi.responses import Response, StreamingResponse
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import Response, StreamingResponse, JSONResponse
 from prometheus_client import (
     Counter,
     Histogram,
@@ -18,7 +17,7 @@ from prometheus_client import (
 import logging
 from logging.handlers import TimedRotatingFileHandler
 
-from typing import AsyncIterator, List, Optional, Dict
+from typing import List, Optional, Dict
 
 import json
 import hashlib
@@ -26,17 +25,9 @@ import hashlib
 import redis.asyncio as redis
 
 
-import httpx
-from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import StreamingResponse, JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
-
 from .utils import stream_resp
-
-from fastapi import FastAPI
-from .schemas import ChatCompletionRequest
-from .providers import anthropic, google, openrouter, grok, venice
 
 from pydantic import BaseModel
 
@@ -95,6 +86,7 @@ REQUEST_LATENCY = Histogram(
     "router_request_latency_seconds",
     "Request latency in seconds",
     labelnames=["backend"],
+)
 
 CACHE_TTL = int(os.getenv("CACHE_TTL", "300"))
 
@@ -123,8 +115,6 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         RATE_LIMIT_STATE[client_ip] = timestamps
         response = await call_next(request)
         return response
-
-
 
 
 app = FastAPI(title="Intelligent Inference Router")
@@ -160,7 +150,6 @@ async def _startup() -> None:
     logger.addHandler(stream_handler)
 
 
-
 class Message(BaseModel):
     role: str
     content: str
@@ -174,8 +163,6 @@ class ChatCompletionRequest(BaseModel):
     stream: Optional[bool] = False
 
 
-
-
 class AgentRegistration(BaseModel):
     name: str
     endpoint: str
@@ -184,6 +171,7 @@ class AgentRegistration(BaseModel):
 
 class AgentHeartbeat(BaseModel):
     name: str
+
 
 def select_backend(payload: ChatCompletionRequest) -> str:
     """Return backend key for the given request."""
@@ -205,10 +193,7 @@ def make_cache_key(payload: ChatCompletionRequest) -> str:
     """Return a Redis cache key for the given request."""
 
     serialized = json.dumps(payload.dict(), sort_keys=True)
-    digest = hashlib.sha256(serialized.encode()).hexdigest()
-
-
-
+    return hashlib.sha256(serialized.encode()).hexdigest()
 
 
 async def forward_to_local_agent(payload: ChatCompletionRequest) -> dict:
@@ -258,7 +243,6 @@ async def forward_to_openai(payload: ChatCompletionRequest):
         return resp.json()
 
 
-
 async def forward_to_llmd(payload: ChatCompletionRequest):
     """Forward request to the llm-d cluster."""
 
@@ -276,7 +260,7 @@ async def forward_to_llmd(payload: ChatCompletionRequest):
                 resp.raise_for_status()
             except httpx.HTTPError as exc:  # coverage: ignore  -- best-effort
                 raise HTTPException(status_code=502, detail="llm-d error") from exc
-            return StreamingResponse(_stream_resp(resp), media_type="text/event-stream")
+            return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
 
         resp = await client.post("/v1/chat/completions", json=payload.dict())
         try:
@@ -284,6 +268,7 @@ async def forward_to_llmd(payload: ChatCompletionRequest):
         except httpx.HTTPError as exc:  # coverage: ignore  -- best-effort
             raise HTTPException(status_code=502, detail="llm-d error") from exc
         return resp.json()
+
 
 @app.post("/register")
 async def register_agent(payload: AgentRegistration) -> dict:
@@ -304,7 +289,6 @@ async def heartbeat(payload: AgentHeartbeat) -> dict:
     with get_session() as session:
         update_heartbeat(session, payload.name)
     return {"status": "ok"}
-
 
 
 @app.post("/v1/chat/completions")
@@ -372,94 +356,3 @@ async def metrics() -> Response:
     """Expose Prometheus metrics."""
 
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
-
-
-    backend = select_backend(payload)
-
-    if backend == "local":
-        return await forward_to_local_agent(payload)
-
-    if backend == "openai":
-        return await forward_to_openai(payload)
-
-    cache_key = make_cache_key(payload)
-    if not payload.stream:
-        cached = await redis_client.get(cache_key)
-        if cached:
-            return json.loads(cached)
-
-    entry = MODEL_REGISTRY.get(payload.model)
-
-    if entry is not None:
-        if entry.type == "local":
-            data = await forward_to_local_agent(payload)
-            if not payload.stream:
-                await redis_client.setex(cache_key, CACHE_TTL, json.dumps(data))
-            return data
-        if entry.type == "openai":
-
-            return await forward_to_openai(payload)
-
-        if entry.type == "llm-d":
-            return await forward_to_llmd(payload)
-
-        if entry.type == "anthropic":
-            return await anthropic.forward(
-                payload, ANTHROPIC_BASE_URL, EXTERNAL_ANTHROPIC_KEY
-            )
-        if entry.type == "google":
-            return await google.forward(payload, GOOGLE_BASE_URL, EXTERNAL_GOOGLE_KEY)
-        if entry.type == "openrouter":
-            return await openrouter.forward(
-                payload, OPENROUTER_BASE_URL, EXTERNAL_OPENROUTER_KEY
-            )
-        if entry.type == "grok":
-            return await grok.forward(payload, GROK_BASE_URL, EXTERNAL_GROK_KEY)
-        if entry.type == "venice":
-            return await venice.forward(payload, VENICE_BASE_URL, EXTERNAL_VENICE_KEY)
-
-            data = await forward_to_openai(payload)
-            if not payload.stream:
-                await redis_client.setex(cache_key, CACHE_TTL, json.dumps(data))
-            return data
-
-
-    if payload.model.startswith("local"):
-        data = await forward_to_local_agent(payload)
-        if not payload.stream:
-            await redis_client.setex(cache_key, CACHE_TTL, json.dumps(data))
-        return data
-
-    if payload.model.startswith("gpt-"):
-        data = await forward_to_openai(payload)
-        if not payload.stream:
-            await redis_client.setex(cache_key, CACHE_TTL, json.dumps(data))
-        return data
-
-
-    if payload.model.startswith("llmd-"):
-        return await forward_to_llmd(payload)
-
-    dummy_text = "Hello world"
-    response = {
-        "id": f"cmpl-{uuid.uuid4().hex}",
-        "object": "chat.completion",
-        "created": int(time.time()),
-        "model": payload.model,
-        "choices": [
-            {
-                "index": 0,
-                "message": {"role": "assistant", "content": dummy_text},
-                "finish_reason": "stop",
-            }
-        ],
-        "usage": {
-            "prompt_tokens": 0,
-            "completion_tokens": 0,
-            "total_tokens": 0,
-        },
-    }
-    if not payload.stream:
-        await redis_client.setex(cache_key, CACHE_TTL, json.dumps(response))
-    return response
-

--- a/router/providers/grok.py
+++ b/router/providers/grok.py
@@ -15,7 +15,9 @@ async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | 
 
     headers = {"Authorization": f"Bearer {api_key}"}
     async with httpx.AsyncClient(base_url=base_url) as client:
-        path = "/v1/chat/completions"
+        # Groq exposes an OpenAI-compatible endpoint under the `/openai` prefix
+        # so we must include it when forwarding requests.
+        path = "/openai/v1/chat/completions"
         if payload.stream:
             resp = await client.post(  # type: ignore[call-arg]
                 path, json=payload.dict(), headers=headers, stream=True

--- a/tests/integration/test_docker_stack.py
+++ b/tests/integration/test_docker_stack.py
@@ -15,7 +15,12 @@ if shutil.which("docker") is None:
 async def docker_stack():
     compose_file = ROOT / "docker-compose.yml"
     up = await asyncio.create_subprocess_exec(
-        "docker", "compose", "-f", str(compose_file), "up", "-d",
+        "docker",
+        "compose",
+        "-f",
+        str(compose_file),
+        "up",
+        "-d",
         cwd=str(ROOT),
     )
     await up.communicate()
@@ -25,7 +30,10 @@ async def docker_stack():
             async with httpx.AsyncClient() as client:
                 resp = await client.post(
                     "http://localhost:8000/v1/chat/completions",
-                    json={"model": "local_test", "messages": [{"role": "user", "content": "hi"}]},
+                    json={
+                        "model": "local_test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
                     timeout=1,
                 )
             if resp.status_code == 200:
@@ -34,7 +42,12 @@ async def docker_stack():
             await asyncio.sleep(1)
     yield
     down = await asyncio.create_subprocess_exec(
-        "docker", "compose", "-f", str(compose_file), "down", "-v",
+        "docker",
+        "compose",
+        "-f",
+        str(compose_file),
+        "down",
+        "-v",
         cwd=str(ROOT),
     )
     await down.communicate()
@@ -45,7 +58,10 @@ async def test_stack_basic(docker_stack):
     async with httpx.AsyncClient() as client:
         resp = await client.post(
             "http://localhost:8000/v1/chat/completions",
-            json={"model": "local_test", "messages": [{"role": "user", "content": "ping"}]},
+            json={
+                "model": "local_test",
+                "messages": [{"role": "user", "content": "ping"}],
+            },
         )
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/local_agent/test_main.py
+++ b/tests/local_agent/test_main.py
@@ -1,4 +1,3 @@
-import pytest
 from fastapi.testclient import TestClient
 
 from local_agent.main import app

--- a/tests/router/test_cli_misc.py
+++ b/tests/router/test_cli_misc.py
@@ -15,13 +15,13 @@ def test_migrate_invokes_create_tables(monkeypatch):
     called = {}
 
     def fake_create_tables():
-        called['yes'] = True
+        called["yes"] = True
 
     monkeypatch.setattr(cli, "create_tables", fake_create_tables)
     runner = CliRunner()
     result = runner.invoke(cli.app, ["migrate"])
     assert result.exit_code == 0
-    assert called.get('yes')
+    assert called.get("yes")
 
 
 def test_seed_reads_file(monkeypatch, tmp_path):

--- a/tests/router/test_provider_grok.py
+++ b/tests/router/test_provider_grok.py
@@ -1,0 +1,102 @@
+import json
+import httpx
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
+
+import router.main as router_main
+import router.registry as registry
+from sqlalchemy import create_engine
+
+
+grok_app = FastAPI()
+
+
+@grok_app.post("/openai/v1/chat/completions")
+async def _completion(payload: router_main.ChatCompletionRequest):
+    user_msg = payload.messages[-1].content if payload.messages else ""
+    if payload.stream:
+
+        async def gen():
+            chunk = json.dumps(
+                {"choices": [{"delta": {"content": f"Grok: {user_msg}"}, "index": 0}]}
+            )
+            yield f"data: {chunk}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+    return {
+        "id": "grok-1",
+        "object": "chat.completion",
+        "created": 0,
+        "model": payload.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": f"Grok: {user_msg}"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
+
+
+def setup_registry(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "models.db"
+    monkeypatch.setattr(router_main, "SQLITE_DB_PATH", str(db_path))
+    registry.SQLITE_DB_PATH = str(db_path)
+    registry.engine = create_engine(f"sqlite:///{db_path}")
+    registry.SessionLocal = registry.sessionmaker(bind=registry.engine)
+    registry.create_tables()
+    with registry.get_session() as session:
+        registry.upsert_model(session, "grok-model", "grok", "unused")
+
+
+def patch_http_client(monkeypatch):
+    real_async_client = httpx.AsyncClient
+    transport = httpx.ASGITransport(app=grok_app)
+
+    def client_factory(*args, **kwargs):
+        return real_async_client(transport=transport, base_url="http://testserver")
+
+    monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
+
+
+def test_forward_to_grok(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(router_main, "GROK_BASE_URL", "http://testserver")
+    monkeypatch.setattr(router_main, "EXTERNAL_GROK_KEY", "dummy")
+
+    setup_registry(monkeypatch, tmp_path)
+    patch_http_client(monkeypatch)
+
+    client = TestClient(router_main.app)
+    payload = {
+        "model": "grok-model",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    response = client.post("/v1/chat/completions", json=payload)
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "Grok: hi"
+
+
+def test_forward_to_grok_stream(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(router_main, "GROK_BASE_URL", "http://testserver")
+    monkeypatch.setattr(router_main, "EXTERNAL_GROK_KEY", "dummy")
+
+    setup_registry(monkeypatch, tmp_path)
+    patch_http_client(monkeypatch)
+
+    client = TestClient(router_main.app)
+    payload = {
+        "model": "grok-model",
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": True,
+    }
+    with client.stream("POST", "/v1/chat/completions", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = list(resp.iter_lines())
+    decoded = [
+        line.decode() if isinstance(line, bytes) else line for line in lines if line
+    ]
+    assert any("Grok: hi" in line for line in decoded)
+    assert decoded[-1] == "data: [DONE]"


### PR DESCRIPTION
## Summary
- fix Grok provider endpoint to include `/openai` prefix
- document Grok env vars in README and `.env.example`
- add Grok provider unit tests for streaming
- mark Grok integration complete in IMPLEMENTATION_STATUS
- clean Makefile and minor lint fixes

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError for prometheus_client, typer, sqlalchemy)*