### PR TITLE
feat: add provider base classes

### DIFF
--- a/router/providers/__init__.py
+++ b/router/providers/__init__.py
@@ -1,3 +1,12 @@
 from . import anthropic, google, openrouter, grok, venice
+from .base import ApiProvider, WeightProvider
 
-__all__ = ["anthropic", "google", "openrouter", "grok", "venice"]
+__all__ = [
+    "ApiProvider",
+    "WeightProvider",
+    "anthropic",
+    "google",
+    "openrouter",
+    "grok",
+    "venice",
+]

--- a/router/providers/anthropic.py
+++ b/router/providers/anthropic.py
@@ -6,33 +6,45 @@ from fastapi.responses import StreamingResponse
 
 from ..schemas import ChatCompletionRequest
 from ..utils import stream_resp
+from .base import ApiProvider
 
 
-async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | None):
-    """Forward request to Anthropic."""
-    if api_key is None:
-        raise HTTPException(status_code=500, detail="Anthropic key not configured")
+class AnthropicProvider(ApiProvider):
+    """Provider wrapper for the Anthropic API."""
 
-    headers = {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
-    async with httpx.AsyncClient(base_url=base_url) as client:
-        path = "/v1/messages"
-        if payload.stream:
-            resp = await client.post(  # type: ignore[call-arg]
-                path, json=payload.dict(), headers=headers, stream=True
-            )
+    async def forward(
+        self, payload: ChatCompletionRequest, base_url: str, api_key: str | None
+    ):
+        """Forward request to Anthropic."""
+        if api_key is None:
+            raise HTTPException(status_code=500, detail="Anthropic key not configured")
+
+        headers = {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
+        async with httpx.AsyncClient(base_url=base_url) as client:
+            path = "/v1/messages"
+            if payload.stream:
+                resp = await client.post(  # type: ignore[call-arg]
+                    path, json=payload.dict(), headers=headers, stream=True
+                )
+                try:
+                    resp.raise_for_status()
+                except httpx.HTTPError as exc:  # coverage: ignore
+                    raise HTTPException(
+                        status_code=502, detail="External provider error"
+                    ) from exc
+                return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
+
+            resp = await client.post(path, json=payload.dict(), headers=headers)
             try:
                 resp.raise_for_status()
             except httpx.HTTPError as exc:  # coverage: ignore
                 raise HTTPException(
                     status_code=502, detail="External provider error"
                 ) from exc
-            return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
+            return resp.json()
 
-        resp = await client.post(path, json=payload.dict(), headers=headers)
-        try:
-            resp.raise_for_status()
-        except httpx.HTTPError as exc:  # coverage: ignore
-            raise HTTPException(
-                status_code=502, detail="External provider error"
-            ) from exc
-        return resp.json()
+
+async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | None):
+    """Backward compatible wrapper for ``AnthropicProvider``."""
+    provider = AnthropicProvider()
+    return await provider.forward(payload, base_url, api_key)

--- a/router/providers/base.py
+++ b/router/providers/base.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from ..schemas import ChatCompletionRequest
+
+
+class ApiProvider:
+    """Base class for providers that forward requests to external APIs."""
+
+    async def forward(
+        self, payload: ChatCompletionRequest,
+        base_url: str,
+        api_key: str | None,
+    ):
+        """Forward a chat completion request."""
+        raise NotImplementedError
+
+
+class WeightProvider:
+    """Base class for providers that load local model weights."""
+
+    async def forward(
+        self, payload: ChatCompletionRequest,
+        base_url: str,
+    ):
+        """Perform inference using local weights."""
+        raise NotImplementedError

--- a/router/providers/grok.py
+++ b/router/providers/grok.py
@@ -6,34 +6,46 @@ from fastapi.responses import StreamingResponse
 
 from ..schemas import ChatCompletionRequest
 from ..utils import stream_resp
+from .base import ApiProvider
 
 
-async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | None):
-    """Forward request to Grok."""
-    if api_key is None:
-        raise HTTPException(status_code=500, detail="Grok key not configured")
+class GrokProvider(ApiProvider):
+    """Provider wrapper for the Grok API."""
 
-    headers = {"Authorization": f"Bearer {api_key}"}
-    async with httpx.AsyncClient(base_url=base_url) as client:
-        # Groq exposes an OpenAI-compatible endpoint under the `/openai` prefix
-        # so we must include it when forwarding requests.
-        path = "/openai/v1/chat/completions"
-        if payload.stream:
-            resp = await client.post(  # type: ignore[call-arg]
-                path, json=payload.dict(), headers=headers, stream=True
-            )
+    async def forward(
+        self, payload: ChatCompletionRequest, base_url: str, api_key: str | None
+    ):
+        """Forward request to Grok."""
+        if api_key is None:
+            raise HTTPException(status_code=500, detail="Grok key not configured")
+
+        headers = {"Authorization": f"Bearer {api_key}"}
+        async with httpx.AsyncClient(base_url=base_url) as client:
+            # Groq exposes an OpenAI-compatible endpoint under the `/openai` prefix
+            # so we must include it when forwarding requests.
+            path = "/openai/v1/chat/completions"
+            if payload.stream:
+                resp = await client.post(  # type: ignore[call-arg]
+                    path, json=payload.dict(), headers=headers, stream=True
+                )
+                try:
+                    resp.raise_for_status()
+                except httpx.HTTPError as exc:  # coverage: ignore
+                    raise HTTPException(
+                        status_code=502, detail="External provider error"
+                    ) from exc
+                return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
+            resp = await client.post(path, json=payload.dict(), headers=headers)
             try:
                 resp.raise_for_status()
             except httpx.HTTPError as exc:  # coverage: ignore
                 raise HTTPException(
                     status_code=502, detail="External provider error"
                 ) from exc
-            return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
-        resp = await client.post(path, json=payload.dict(), headers=headers)
-        try:
-            resp.raise_for_status()
-        except httpx.HTTPError as exc:  # coverage: ignore
-            raise HTTPException(
-                status_code=502, detail="External provider error"
-            ) from exc
-        return resp.json()
+            return resp.json()
+
+
+async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | None):
+    """Backward compatible wrapper for ``GrokProvider``."""
+    provider = GrokProvider()
+    return await provider.forward(payload, base_url, api_key)

--- a/router/providers/openrouter.py
+++ b/router/providers/openrouter.py
@@ -6,32 +6,44 @@ from fastapi.responses import StreamingResponse
 
 from ..schemas import ChatCompletionRequest
 from ..utils import stream_resp
+from .base import ApiProvider
 
 
-async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | None):
-    """Forward request to OpenRouter."""
-    if api_key is None:
-        raise HTTPException(status_code=500, detail="OpenRouter key not configured")
+class OpenRouterProvider(ApiProvider):
+    """Provider wrapper for the OpenRouter API."""
 
-    headers = {"Authorization": f"Bearer {api_key}"}
-    async with httpx.AsyncClient(base_url=base_url) as client:
-        path = "/api/v1/chat/completions"
-        if payload.stream:
-            resp = await client.post(  # type: ignore[call-arg]
-                path, json=payload.dict(), headers=headers, stream=True
-            )
+    async def forward(
+        self, payload: ChatCompletionRequest, base_url: str, api_key: str | None
+    ):
+        """Forward request to OpenRouter."""
+        if api_key is None:
+            raise HTTPException(status_code=500, detail="OpenRouter key not configured")
+
+        headers = {"Authorization": f"Bearer {api_key}"}
+        async with httpx.AsyncClient(base_url=base_url) as client:
+            path = "/api/v1/chat/completions"
+            if payload.stream:
+                resp = await client.post(  # type: ignore[call-arg]
+                    path, json=payload.dict(), headers=headers, stream=True
+                )
+                try:
+                    resp.raise_for_status()
+                except httpx.HTTPError as exc:  # coverage: ignore
+                    raise HTTPException(
+                        status_code=502, detail="External provider error"
+                    ) from exc
+                return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
+            resp = await client.post(path, json=payload.dict(), headers=headers)
             try:
                 resp.raise_for_status()
             except httpx.HTTPError as exc:  # coverage: ignore
                 raise HTTPException(
                     status_code=502, detail="External provider error"
                 ) from exc
-            return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
-        resp = await client.post(path, json=payload.dict(), headers=headers)
-        try:
-            resp.raise_for_status()
-        except httpx.HTTPError as exc:  # coverage: ignore
-            raise HTTPException(
-                status_code=502, detail="External provider error"
-            ) from exc
-        return resp.json()
+            return resp.json()
+
+
+async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | None):
+    """Backward compatible wrapper for ``OpenRouterProvider``."""
+    provider = OpenRouterProvider()
+    return await provider.forward(payload, base_url, api_key)

--- a/router/providers/venice.py
+++ b/router/providers/venice.py
@@ -6,32 +6,44 @@ from fastapi.responses import StreamingResponse
 
 from ..schemas import ChatCompletionRequest
 from ..utils import stream_resp
+from .base import ApiProvider
 
 
-async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | None):
-    """Forward request to Venice."""
-    if api_key is None:
-        raise HTTPException(status_code=500, detail="Venice key not configured")
+class VeniceProvider(ApiProvider):
+    """Provider wrapper for the Venice API."""
 
-    headers = {"Authorization": f"Bearer {api_key}"}
-    async with httpx.AsyncClient(base_url=base_url) as client:
-        path = "/v1/chat/completions"
-        if payload.stream:
-            resp = await client.post(  # type: ignore[call-arg]
-                path, json=payload.dict(), headers=headers, stream=True
-            )
+    async def forward(
+        self, payload: ChatCompletionRequest, base_url: str, api_key: str | None
+    ):
+        """Forward request to Venice."""
+        if api_key is None:
+            raise HTTPException(status_code=500, detail="Venice key not configured")
+
+        headers = {"Authorization": f"Bearer {api_key}"}
+        async with httpx.AsyncClient(base_url=base_url) as client:
+            path = "/v1/chat/completions"
+            if payload.stream:
+                resp = await client.post(  # type: ignore[call-arg]
+                    path, json=payload.dict(), headers=headers, stream=True
+                )
+                try:
+                    resp.raise_for_status()
+                except httpx.HTTPError as exc:  # coverage: ignore
+                    raise HTTPException(
+                        status_code=502, detail="External provider error"
+                    ) from exc
+                return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
+            resp = await client.post(path, json=payload.dict(), headers=headers)
             try:
                 resp.raise_for_status()
             except httpx.HTTPError as exc:  # coverage: ignore
                 raise HTTPException(
                     status_code=502, detail="External provider error"
                 ) from exc
-            return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
-        resp = await client.post(path, json=payload.dict(), headers=headers)
-        try:
-            resp.raise_for_status()
-        except httpx.HTTPError as exc:  # coverage: ignore
-            raise HTTPException(
-                status_code=502, detail="External provider error"
-            ) from exc
-        return resp.json()
+            return resp.json()
+
+
+async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | None):
+    """Backward compatible wrapper for ``VeniceProvider``."""
+    provider = VeniceProvider()
+    return await provider.forward(payload, base_url, api_key)


### PR DESCRIPTION
## Summary
- add `ApiProvider` and `WeightProvider` base classes
- refactor provider modules to subclass `ApiProvider`
- export new classes from `router.providers`

## Testing
- `make lint` *(fails: Found 48 ruff errors)*
- `make test` *(fails: ModuleNotFoundError for `prometheus_client`)*


------
https://chatgpt.com/codex/tasks/task_b_6839f96a5d1c8330b777263b47736e81