### PR TITLE
Support weight providers in router

### DIFF
--- a/router/providers/anthropic.py
+++ b/router/providers/anthropic.py
@@ -32,7 +32,9 @@ class AnthropicProvider(ApiProvider):
                     raise HTTPException(
                         status_code=502, detail="External provider error"
                     ) from exc
-                return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
+                return StreamingResponse(
+                    stream_resp(resp), media_type="text/event-stream"
+                )
 
             resp = await client.post(path, json=payload.dict(), headers=headers)
             try:

--- a/router/providers/base.py
+++ b/router/providers/base.py
@@ -7,7 +7,8 @@ class ApiProvider:
     """Base class for providers that forward requests to external APIs."""
 
     async def forward(
-        self, payload: ChatCompletionRequest,
+        self,
+        payload: ChatCompletionRequest,
         base_url: str,
         api_key: str | None,
     ):
@@ -19,7 +20,8 @@ class WeightProvider:
     """Base class for providers that load local model weights."""
 
     async def forward(
-        self, payload: ChatCompletionRequest,
+        self,
+        payload: ChatCompletionRequest,
         base_url: str,
     ):
         """Perform inference using local weights."""

--- a/router/providers/google.py
+++ b/router/providers/google.py
@@ -36,7 +36,9 @@ class GoogleProvider(ApiProvider):
                     raise HTTPException(
                         status_code=502, detail="External provider error"
                     ) from exc
-                return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
+                return StreamingResponse(
+                    stream_resp(resp), media_type="text/event-stream"
+                )
 
             resp = await client.post(path, json=payload.dict(), params=params)
             try:

--- a/router/providers/grok.py
+++ b/router/providers/grok.py
@@ -34,7 +34,9 @@ class GrokProvider(ApiProvider):
                     raise HTTPException(
                         status_code=502, detail="External provider error"
                     ) from exc
-                return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
+                return StreamingResponse(
+                    stream_resp(resp), media_type="text/event-stream"
+                )
             resp = await client.post(path, json=payload.dict(), headers=headers)
             try:
                 resp.raise_for_status()

--- a/router/providers/huggingface.py
+++ b/router/providers/huggingface.py
@@ -4,7 +4,7 @@ import os
 import uuid
 import time
 import asyncio
-from typing import Dict
+from typing import Dict, Any
 
 from huggingface_hub import snapshot_download
 from transformers import pipeline
@@ -19,7 +19,7 @@ class HuggingFaceProvider(WeightProvider):
     def __init__(self) -> None:
         self.cache_dir = os.getenv("HF_CACHE_DIR", "data/hf_models")
         self.device = os.getenv("HF_DEVICE", "cpu")
-        self._pipelines: Dict[str, any] = {}
+        self._pipelines: Dict[str, Any] = {}
 
     def _get_pipeline(self, model_id: str):
         pipe = self._pipelines.get(model_id)

--- a/router/providers/openai.py
+++ b/router/providers/openai.py
@@ -32,7 +32,9 @@ class OpenAIProvider(ApiProvider):
                     raise HTTPException(
                         status_code=502, detail="External provider error"
                     ) from exc
-                return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
+                return StreamingResponse(
+                    stream_resp(resp), media_type="text/event-stream"
+                )
 
             resp = await client.post(path, json=payload.dict(), headers=headers)
             try:

--- a/router/providers/openrouter.py
+++ b/router/providers/openrouter.py
@@ -32,7 +32,9 @@ class OpenRouterProvider(ApiProvider):
                     raise HTTPException(
                         status_code=502, detail="External provider error"
                     ) from exc
-                return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
+                return StreamingResponse(
+                    stream_resp(resp), media_type="text/event-stream"
+                )
             resp = await client.post(path, json=payload.dict(), headers=headers)
             try:
                 resp.raise_for_status()

--- a/router/providers/venice.py
+++ b/router/providers/venice.py
@@ -32,7 +32,9 @@ class VeniceProvider(ApiProvider):
                     raise HTTPException(
                         status_code=502, detail="External provider error"
                     ) from exc
-                return StreamingResponse(stream_resp(resp), media_type="text/event-stream")
+                return StreamingResponse(
+                    stream_resp(resp), media_type="text/event-stream"
+                )
             resp = await client.post(path, json=payload.dict(), headers=headers)
             try:
                 resp.raise_for_status()

--- a/tests/router/test_provider_huggingface.py
+++ b/tests/router/test_provider_huggingface.py
@@ -7,7 +7,13 @@ from router.schemas import ChatCompletionRequest, Message
 
 
 class DummyPipe:
-    def __call__(self, prompt: str, max_new_tokens: int, temperature: float, return_full_text: bool):
+    def __call__(
+        self,
+        prompt: str,
+        max_new_tokens: int,
+        temperature: float,
+        return_full_text: bool,
+    ):
         return [{"generated_text": f"HF: {prompt}"}]
 
 
@@ -20,4 +26,3 @@ def test_forward(monkeypatch) -> None:
     )
     data = asyncio.run(provider.forward(payload, base_url="unused"))
     assert data["choices"][0]["message"]["content"] == "HF: hello"
-

--- a/tests/router/test_weight_provider_router.py
+++ b/tests/router/test_weight_provider_router.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+
+import router.main as router_main
+import router.registry as registry
+from router.providers import huggingface
+from sqlalchemy import create_engine
+
+
+class DummyPipe:
+    def __call__(
+        self,
+        prompt: str,
+        max_new_tokens: int,
+        temperature: float,
+        return_full_text: bool,
+    ):
+        return [{"generated_text": f"HF: {prompt}"}]
+
+
+def test_forward_to_weight_provider(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "models.db"
+    monkeypatch.setattr(router_main, "SQLITE_DB_PATH", str(db_path))
+    registry.SQLITE_DB_PATH = str(db_path)
+    registry.engine = create_engine(f"sqlite:///{db_path}")
+    registry.SessionLocal = registry.sessionmaker(bind=registry.engine)
+    registry.create_tables()
+    with registry.get_session() as session:
+        registry.upsert_model(session, "hf-model", "huggingface", "unused", "weight")
+    provider = huggingface.HuggingFaceProvider()
+    monkeypatch.setattr(provider, "_get_pipeline", lambda m: DummyPipe())
+    router_main.WEIGHT_PROVIDERS.clear()
+    router_main.WEIGHT_PROVIDERS["huggingface"] = provider
+    client = TestClient(router_main.app)
+    payload = {"model": "hf-model", "messages": [{"role": "user", "content": "hi"}]}
+    resp = client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["message"]["content"] == "HF: hi"


### PR DESCRIPTION
## Summary
- allow reusable weight providers in router
- test weight provider routing
- run `black` on provider modules for lint compliance

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_b_683a162ba0408330ac30f9163c598199