### PR TITLE
Update provider docs and env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ EXTERNAL_VENICE_KEY=
 # Hugging Face local model settings
 HF_CACHE_DIR=data/hf_models
 HF_DEVICE=cpu
+HUGGING_FACE_HUB_TOKEN=
 
 # Rate limiting settings
 RATE_LIMIT_REQUESTS=60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Venice provider forwarding support
 - Hugging Face weight provider for local models
 - Model registry `kind` column with migration and CLI support
+- Unified provider architecture for API and weight-based providers
+- Example Hugging Face env vars in `.env.example`
 
 
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ Add or update a single model entry:
 python -m router.cli add-model <name> <type> <endpoint> [kind]
 ```
 
+Register a Hugging Face model that uses local weights:
+
+```bash
+python -m router.cli add-model meta-llama/Llama-3 huggingface https://huggingface.co weight
+```
+
 Fetch the latest models from OpenAI and refresh the registry:
 
 ```bash

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -62,6 +62,8 @@ Features and integrations planned for after the MVP:
   - Grok
   - Venice
   - Hugging Face
+- Unified provider architecture with `ApiProvider` and `WeightProvider`
+  classes to support both remote APIs and local weights.
 
 ---
 

--- a/docs/router_api.md
+++ b/docs/router_api.md
@@ -88,6 +88,9 @@ GROK_BASE_URL=https://api.groq.com
 EXTERNAL_GROK_KEY=...
 VENICE_BASE_URL=https://api.venice.ai
 EXTERNAL_VENICE_KEY=...
+HF_CACHE_DIR=data/hf_models
+HF_DEVICE=cpu
+HUGGING_FACE_HUB_TOKEN=
 ```
 
 
@@ -109,11 +112,29 @@ ROUTER_COST_THRESHOLD=1000  # route locally if cost exceeds this value
 
 If omitted, the router falls back to the values defined in the project config.
 
+### Provider Architecture
+
+Providers come in two flavors:
+
+- **ApiProvider** – forwards requests to an external HTTP API.
+- **WeightProvider** – loads model weights locally and performs inference.
+
+Each provider implementation lives under `router/providers/`. The model
+registry's `kind` column indicates whether a model should use API forwarding or
+local weights. Weight providers like `huggingface` download and cache models in
+`HF_CACHE_DIR` and respect `HF_DEVICE`.
+
 
 
 Set the relevant keys before starting the server. Models for each provider must
 be added to the registry using `router.cli add-model` (optionally passing
 `kind=api|weight`) or `refresh-openai` for OpenAI.
+
+Example for a weight-based Hugging Face model:
+
+```bash
+python -m router.cli add-model meta-llama/Llama-3 huggingface https://huggingface.co weight
+```
 
 Valid model types are `local`, `openai`, `llm-d`, `anthropic`, `google`,
 `openrouter`, `grok`, and `venice`.


### PR DESCRIPTION
## Summary
- document provider architecture
- add Hugging Face variables to `.env.example`
- include CLI example for weight-based models

## Testing
- `make lint`
- `make test` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_b_683a1829fda883308ae3828bb50d7524