### PR TITLE
Extend provider tests

### DIFF
--- a/tests/router/test_provider_base.py
+++ b/tests/router/test_provider_base.py
@@ -1,0 +1,29 @@
+import asyncio
+import sys
+import types
+import pytest
+
+# Provide stub modules for optional dependencies
+hub_stub = types.ModuleType("huggingface_hub")
+hub_stub.snapshot_download = lambda *args, **kwargs: None
+trans_stub = types.ModuleType("transformers")
+trans_stub.pipeline = lambda *args, **kwargs: None
+sys.modules.setdefault("huggingface_hub", hub_stub)
+sys.modules.setdefault("transformers", trans_stub)
+
+from router.providers.base import ApiProvider, WeightProvider
+from router.schemas import ChatCompletionRequest, Message
+
+
+def test_api_provider_not_implemented():
+    provider = ApiProvider()
+    payload = ChatCompletionRequest(model="m", messages=[Message(role="user", content="hi")])
+    with pytest.raises(NotImplementedError):
+        asyncio.run(provider.forward(payload, base_url="x", api_key="k"))
+
+
+def test_weight_provider_not_implemented():
+    provider = WeightProvider()
+    payload = ChatCompletionRequest(model="m", messages=[Message(role="user", content="hi")])
+    with pytest.raises(NotImplementedError):
+        asyncio.run(provider.forward(payload, base_url="x"))

--- a/tests/router/test_provider_huggingface.py
+++ b/tests/router/test_provider_huggingface.py
@@ -1,6 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+import types
+
+# Stub optional dependencies so the provider can be imported
+hub_stub = types.ModuleType("huggingface_hub")
+hub_stub.snapshot_download = lambda *args, **kwargs: None
+trans_stub = types.ModuleType("transformers")
+trans_stub.pipeline = lambda *args, **kwargs: None
+sys.modules.setdefault("huggingface_hub", hub_stub)
+sys.modules.setdefault("transformers", trans_stub)
 
 from router.providers.huggingface import HuggingFaceProvider
 from router.schemas import ChatCompletionRequest, Message
@@ -26,3 +36,41 @@ def test_forward(monkeypatch) -> None:
     )
     data = asyncio.run(provider.forward(payload, base_url="unused"))
     assert data["choices"][0]["message"]["content"] == "HF: hello"
+
+
+def test_get_pipeline_download_and_cache(monkeypatch, tmp_path) -> None:
+    provider = HuggingFaceProvider()
+    provider.cache_dir = str(tmp_path)
+
+    calls = {"download": 0, "pipeline": 0}
+
+    def fake_exists(path: str) -> bool:
+        return False
+
+    def fake_snapshot_download(repo_id: str, local_dir: str, local_dir_use_symlinks: bool) -> None:
+        calls["download"] += 1
+        assert repo_id == "test/model"
+        assert local_dir == str(tmp_path / "test_model")
+        assert local_dir_use_symlinks is False
+
+    dummy_pipe = object()
+
+    def fake_pipeline(task: str, model: str, tokenizer: str, device: int):
+        calls["pipeline"] += 1
+        assert task == "text-generation"
+        assert model == str(tmp_path / "test_model")
+        assert tokenizer == str(tmp_path / "test_model")
+        assert device == -1
+        return dummy_pipe
+
+    monkeypatch.setattr("router.providers.huggingface.os.path.exists", fake_exists)
+    monkeypatch.setattr("router.providers.huggingface.snapshot_download", fake_snapshot_download)
+    monkeypatch.setattr("router.providers.huggingface.pipeline", fake_pipeline)
+
+    pipe1 = provider._get_pipeline("test/model")
+    assert pipe1 is dummy_pipe
+    assert calls == {"download": 1, "pipeline": 1}
+
+    pipe2 = provider._get_pipeline("test/model")
+    assert pipe2 is dummy_pipe
+    assert calls == {"download": 1, "pipeline": 1}


### PR DESCRIPTION
## Summary
- add tests for `ApiProvider` and `WeightProvider`
- expand HuggingFace provider tests with mocked snapshot download

## Testing
- `pytest tests/router/test_provider_base.py tests/router/test_provider_huggingface.py -q`
- `pytest -q` *(fails: `ModuleNotFoundError: No module named 'prometheus_client'`)*

------
https://chatgpt.com/codex/tasks/task_b_683a1a68cc1483308d1076b8211854fa