### PR TITLE
Document provider architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,9 @@ EXTERNAL_VENICE_KEY=
 
 # Hugging Face local model settings
 HF_CACHE_DIR=data/hf_models
+# Set to 'cuda' when running on a GPU host
 HF_DEVICE=cpu
+# Optional token for private repos
 HUGGING_FACE_HUB_TOKEN=
 
 # Rate limiting settings

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -61,9 +61,14 @@ Features and integrations planned for after the MVP:
   - OpenRouter
   - Grok
   - Venice
-  - Hugging Face
+- Hugging Face
 - Unified provider architecture with `ApiProvider` and `WeightProvider`
   classes to support both remote APIs and local weights.
+
+The router inspects the model's `kind` (`api` or `weight`) to decide whether to
+forward the request to a remote service or load local weights via a provider
+like `huggingface`. Each provider under `router/providers/` implements one of
+these base classes.
 
 ---
 

--- a/docs/router_api.md
+++ b/docs/router_api.md
@@ -114,25 +114,30 @@ If omitted, the router falls back to the values defined in the project config.
 
 ### Provider Architecture
 
-Providers come in two flavors:
+Version&nbsp;0.2 introduced a unified provider layer. Every backend now derives
+from one of two base classes:
 
-- **ApiProvider** – forwards requests to an external HTTP API.
-- **WeightProvider** – loads model weights locally and performs inference.
+- **`ApiProvider`** – forwards requests to a remote HTTP API.
+- **`WeightProvider`** – loads model weights locally and performs inference.
 
-Each provider implementation lives under `router/providers/`. The model
-registry's `kind` column indicates whether a model should use API forwarding or
-local weights. Weight providers like `huggingface` download and cache models in
-`HF_CACHE_DIR` and respect `HF_DEVICE`.
+Provider implementations live under `router/providers/`. The router looks at the
+`kind` column of the model registry to decide which class to instantiate.
 
-
+Weight providers such as `huggingface` download and cache models in
+`HF_CACHE_DIR` and respect `HF_DEVICE`. API providers (OpenAI, Anthropic,
+Google, OpenRouter, Grok and Venice) simply forward the request with the
+appropriate API key.
 
 Set the relevant keys before starting the server. Models for each provider must
-be added to the registry using `router.cli add-model` (optionally passing
-`kind=api|weight`) or `refresh-openai` for OpenAI.
+be added to the registry using `router.cli add-model` (pass `kind=api` or
+`kind=weight`) or via `refresh-openai` for OpenAI models.
 
-Example for a weight-based Hugging Face model:
+#### Registering Weight-Based Models
+
+Use the CLI to register models that run locally:
 
 ```bash
+python -m router.cli add-model local_mistral local http://localhost:5000 weight
 python -m router.cli add-model meta-llama/Llama-3 huggingface https://huggingface.co weight
 ```
 

--- a/tests/router/test_provider_base.py
+++ b/tests/router/test_provider_base.py
@@ -5,25 +5,29 @@ import pytest
 
 # Provide stub modules for optional dependencies
 hub_stub = types.ModuleType("huggingface_hub")
-hub_stub.snapshot_download = lambda *args, **kwargs: None
+hub_stub.snapshot_download = lambda *args, **kwargs: None  # type: ignore[attr-defined]
 trans_stub = types.ModuleType("transformers")
-trans_stub.pipeline = lambda *args, **kwargs: None
+trans_stub.pipeline = lambda *args, **kwargs: None  # type: ignore[attr-defined]
 sys.modules.setdefault("huggingface_hub", hub_stub)
 sys.modules.setdefault("transformers", trans_stub)
 
-from router.providers.base import ApiProvider, WeightProvider
-from router.schemas import ChatCompletionRequest, Message
+from router.providers.base import ApiProvider, WeightProvider  # noqa: E402
+from router.schemas import ChatCompletionRequest, Message  # noqa: E402
 
 
 def test_api_provider_not_implemented():
     provider = ApiProvider()
-    payload = ChatCompletionRequest(model="m", messages=[Message(role="user", content="hi")])
+    payload = ChatCompletionRequest(
+        model="m", messages=[Message(role="user", content="hi")]
+    )
     with pytest.raises(NotImplementedError):
         asyncio.run(provider.forward(payload, base_url="x", api_key="k"))
 
 
 def test_weight_provider_not_implemented():
     provider = WeightProvider()
-    payload = ChatCompletionRequest(model="m", messages=[Message(role="user", content="hi")])
+    payload = ChatCompletionRequest(
+        model="m", messages=[Message(role="user", content="hi")]
+    )
     with pytest.raises(NotImplementedError):
         asyncio.run(provider.forward(payload, base_url="x"))

--- a/tests/router/test_provider_huggingface.py
+++ b/tests/router/test_provider_huggingface.py
@@ -6,14 +6,14 @@ import types
 
 # Stub optional dependencies so the provider can be imported
 hub_stub = types.ModuleType("huggingface_hub")
-hub_stub.snapshot_download = lambda *args, **kwargs: None
+hub_stub.snapshot_download = lambda *args, **kwargs: None  # type: ignore[attr-defined]
 trans_stub = types.ModuleType("transformers")
-trans_stub.pipeline = lambda *args, **kwargs: None
+trans_stub.pipeline = lambda *args, **kwargs: None  # type: ignore[attr-defined]
 sys.modules.setdefault("huggingface_hub", hub_stub)
 sys.modules.setdefault("transformers", trans_stub)
 
-from router.providers.huggingface import HuggingFaceProvider
-from router.schemas import ChatCompletionRequest, Message
+from router.providers.huggingface import HuggingFaceProvider  # noqa: E402
+from router.schemas import ChatCompletionRequest, Message  # noqa: E402
 
 
 class DummyPipe:
@@ -47,7 +47,9 @@ def test_get_pipeline_download_and_cache(monkeypatch, tmp_path) -> None:
     def fake_exists(path: str) -> bool:
         return False
 
-    def fake_snapshot_download(repo_id: str, local_dir: str, local_dir_use_symlinks: bool) -> None:
+    def fake_snapshot_download(
+        repo_id: str, local_dir: str, local_dir_use_symlinks: bool
+    ) -> None:
         calls["download"] += 1
         assert repo_id == "test/model"
         assert local_dir == str(tmp_path / "test_model")
@@ -64,7 +66,9 @@ def test_get_pipeline_download_and_cache(monkeypatch, tmp_path) -> None:
         return dummy_pipe
 
     monkeypatch.setattr("router.providers.huggingface.os.path.exists", fake_exists)
-    monkeypatch.setattr("router.providers.huggingface.snapshot_download", fake_snapshot_download)
+    monkeypatch.setattr(
+        "router.providers.huggingface.snapshot_download", fake_snapshot_download
+    )
     monkeypatch.setattr("router.providers.huggingface.pipeline", fake_pipeline)
 
     pipe1 = provider._get_pipeline("test/model")


### PR DESCRIPTION
## Summary
- document ApiProvider/WeightProvider design in router_api
- clarify provider architecture bullet in FEATURES
- show how to register weight-based models from CLI
- add Hugging Face env var examples
- clean up provider tests for linting

## Testing
- `make lint`
- `make test` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_b_683b1ec8c3a08330b3d5a0c061d2ea5a