### PR TITLE
Update local agent docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ For local models, run the Local Agent service:
 
 ```bash
 uvicorn local_agent.main:app --port 5000
+# or
+python -m local_agent.main
 ```
 
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -170,7 +170,7 @@ so that routing rules are configurable without code changes.
 **User story:** As a Mac user I want a lightweight HTTP service that runs a local model
 so that I can process prompts offline.
 **Acceptance criteria:**
-- ✅ Agent starts via `python local_agent/main.py` on macOS.
+- ✅ Agent starts via `uvicorn local_agent.main:app --port 5000` on macOS.
 - ✅ `POST /infer` accepts prompt and generation params.
 - ✅ Uses PyTorch MPS to load default model `local_mistral-7b-instruct-q4`.
 **Implementation hints:**

--- a/local_agent/main.py
+++ b/local_agent/main.py
@@ -90,3 +90,9 @@ async def infer(payload: ChatCompletionRequest):
         },
     }
     return response
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("local_agent.main:app", port=5000)

--- a/tests/router/test_provider_huggingface.py
+++ b/tests/router/test_provider_huggingface.py
@@ -79,6 +79,7 @@ def test_get_pipeline_download_and_cache(monkeypatch, tmp_path) -> None:
     assert pipe2 is dummy_pipe
     assert calls == {"download": 1, "pipeline": 1}
 
+
 def test_get_pipeline_respects_device_env(monkeypatch, tmp_path):
     monkeypatch.setenv("HF_DEVICE", "cuda")
     provider = HuggingFaceProvider()


### PR DESCRIPTION
## Summary
- document uvicorn command for running local agent
- allow `python -m local_agent.main`
- format Hugging Face provider test

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError for `prometheus_client`)*

------
https://chatgpt.com/codex/tasks/task_b_683b61e26cb08330b57da0d4dfeed683