### PR TITLE
Add Local Agent env var docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ uvicorn local_agent.main:app --port 5000
 python -m local_agent.main
 ```
 
+See [docs/local_agent.md](docs/local_agent.md) for configuration options and environment variables.
 
 Any request whose `model` starts with `local` will be forwarded to this agent.
 

--- a/docs/local_agent.md
+++ b/docs/local_agent.md
@@ -1,0 +1,28 @@
+# Local Agent
+
+The Local Agent runs on macOS and forwards completion requests to a local model. It registers with the Router so the gateway knows which models are available.
+
+## Environment Variables
+
+Set these variables in your shell or a `.env` file before starting the service. Defaults are shown in parentheses.
+
+| Variable | Default | Description |
+|---------|---------|-------------|
+| `ROUTER_URL` | `http://localhost:8000` | Router base URL used for registration and heartbeats |
+| `HEARTBEAT_INTERVAL` | `30` | Seconds between heartbeat pings |
+| `AGENT_NAME` | `local-agent` | Name reported to the Router |
+| `AGENT_ENDPOINT` | `http://localhost:5000` | Public URL where the agent listens |
+| `MODEL_LIST` | `local_mistral-7b-instruct-q4` | Comma-separated models served |
+
+Start the agent with:
+
+```bash
+uvicorn local_agent.main:app --port 5000
+```
+
+For example, to register under a different name:
+
+```bash
+export AGENT_NAME=my-macos-agent
+uvicorn local_agent.main:app --port 5000
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,5 +14,6 @@ nav:
   - Feature Checklist: FEATURES.md
   - Setup: setup.md
   - Usage: usage.md
+  - Local Agent: local_agent.md
   - API Examples: api_examples.md
   - Router API: router_api.md


### PR DESCRIPTION
## Summary
- explain how to configure the Local Agent via environment variables
- link the new Local Agent docs from the README
- list Local Agent page in the MkDocs nav

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_b_683b74b279088330aaabce813ab40ee1