### PR TITLE
fix: adjust GPT backend routing

### DIFF
--- a/router/main.py
+++ b/router/main.py
@@ -254,11 +254,11 @@ def select_backend(payload: ChatCompletionRequest) -> str:
         cost = _request_cost(payload)
         if cost >= ROUTER_COST_THRESHOLD:
             return "local"
-        local_lat = BACKEND_METRICS.get("local", {}).get("latency", 0.0)
-        openai_lat = BACKEND_METRICS.get("openai", {}).get("latency", 0.0)
-        local_score = ROUTER_LATENCY_WEIGHT * local_lat
-        openai_score = ROUTER_LATENCY_WEIGHT * openai_lat + ROUTER_COST_WEIGHT * cost
-        return "local" if local_score <= openai_score else "openai"
+        local_lat = BACKEND_METRICS.get("local", {}).get("latency")
+        openai_lat = BACKEND_METRICS.get("openai", {}).get("latency")
+        if local_lat is None or openai_lat is None:
+            return "local"
+        return "openai" if openai_lat < local_lat else "local"
 
     if payload.model.startswith("llmd-"):
         return "llm-d"


### PR DESCRIPTION
## Summary
- simplify `select_backend` logic for GPT models

## Testing
- `make lint`
- `make test` *(fails: multiple test failures)*
- `pytest -q tests/router/test_routing_helper.py::test_select_backend_latency`

------
https://chatgpt.com/codex/tasks/task_b_683c7d4209448330ba8d36631d59db58