### PR TITLE
Fix router tests and streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Model registry `kind` column with migration and CLI support
 - Unified provider architecture for API and weight-based providers
 - Example Hugging Face env vars in `.env.example`
+- Updated provider streaming logic for HTTPX 0.28 and closed TestClient sessions in tests
 
 
 

--- a/router/providers/anthropic.py
+++ b/router/providers/anthropic.py
@@ -5,7 +5,8 @@ from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 
 from ..schemas import ChatCompletionRequest
-from ..utils import stream_resp
+from typing import AsyncIterator
+
 from .base import ApiProvider
 
 
@@ -20,22 +21,26 @@ class AnthropicProvider(ApiProvider):
             raise HTTPException(status_code=500, detail="Anthropic key not configured")
 
         headers = {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
-        async with httpx.AsyncClient(base_url=base_url) as client:
-            path = "/v1/messages"
-            if payload.stream:
-                resp = await client.post(  # type: ignore[call-arg]
-                    path, json=payload.dict(), headers=headers, stream=True
-                )
-                try:
-                    resp.raise_for_status()
-                except httpx.HTTPError as exc:  # coverage: ignore
-                    raise HTTPException(
-                        status_code=502, detail="External provider error"
-                    ) from exc
-                return StreamingResponse(
-                    stream_resp(resp), media_type="text/event-stream"
-                )
+        path = "/v1/messages"
+        if payload.stream:
 
+            async def gen() -> AsyncIterator[str]:
+                async with httpx.AsyncClient(base_url=base_url) as client:
+                    async with client.stream(
+                        "POST", path, json=payload.dict(), headers=headers
+                    ) as resp:
+                        try:
+                            resp.raise_for_status()
+                        except httpx.HTTPError as exc:  # coverage: ignore
+                            raise HTTPException(
+                                status_code=502, detail="External provider error"
+                            ) from exc
+                        async for chunk in resp.aiter_text():
+                            yield chunk
+
+            return StreamingResponse(gen(), media_type="text/event-stream")
+
+        async with httpx.AsyncClient(base_url=base_url) as client:
             resp = await client.post(path, json=payload.dict(), headers=headers)
             try:
                 resp.raise_for_status()

--- a/router/providers/openrouter.py
+++ b/router/providers/openrouter.py
@@ -5,7 +5,8 @@ from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 
 from ..schemas import ChatCompletionRequest
-from ..utils import stream_resp
+from typing import AsyncIterator
+
 from .base import ApiProvider
 
 
@@ -20,21 +21,26 @@ class OpenRouterProvider(ApiProvider):
             raise HTTPException(status_code=500, detail="OpenRouter key not configured")
 
         headers = {"Authorization": f"Bearer {api_key}"}
+        path = "/api/v1/chat/completions"
+        if payload.stream:
+
+            async def gen() -> AsyncIterator[str]:
+                async with httpx.AsyncClient(base_url=base_url) as client:
+                    async with client.stream(
+                        "POST", path, json=payload.dict(), headers=headers
+                    ) as resp:
+                        try:
+                            resp.raise_for_status()
+                        except httpx.HTTPError as exc:  # coverage: ignore
+                            raise HTTPException(
+                                status_code=502, detail="External provider error"
+                            ) from exc
+                        async for chunk in resp.aiter_text():
+                            yield chunk
+
+            return StreamingResponse(gen(), media_type="text/event-stream")
+
         async with httpx.AsyncClient(base_url=base_url) as client:
-            path = "/api/v1/chat/completions"
-            if payload.stream:
-                resp = await client.post(  # type: ignore[call-arg]
-                    path, json=payload.dict(), headers=headers, stream=True
-                )
-                try:
-                    resp.raise_for_status()
-                except httpx.HTTPError as exc:  # coverage: ignore
-                    raise HTTPException(
-                        status_code=502, detail="External provider error"
-                    ) from exc
-                return StreamingResponse(
-                    stream_resp(resp), media_type="text/event-stream"
-                )
             resp = await client.post(path, json=payload.dict(), headers=headers)
             try:
                 resp.raise_for_status()

--- a/router/providers/venice.py
+++ b/router/providers/venice.py
@@ -5,7 +5,8 @@ from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 
 from ..schemas import ChatCompletionRequest
-from ..utils import stream_resp
+from typing import AsyncIterator
+
 from .base import ApiProvider
 
 
@@ -20,21 +21,26 @@ class VeniceProvider(ApiProvider):
             raise HTTPException(status_code=500, detail="Venice key not configured")
 
         headers = {"Authorization": f"Bearer {api_key}"}
+        path = "/v1/chat/completions"
+        if payload.stream:
+
+            async def gen() -> AsyncIterator[str]:
+                async with httpx.AsyncClient(base_url=base_url) as client:
+                    async with client.stream(
+                        "POST", path, json=payload.dict(), headers=headers
+                    ) as resp:
+                        try:
+                            resp.raise_for_status()
+                        except httpx.HTTPError as exc:  # coverage: ignore
+                            raise HTTPException(
+                                status_code=502, detail="External provider error"
+                            ) from exc
+                        async for chunk in resp.aiter_text():
+                            yield chunk
+
+            return StreamingResponse(gen(), media_type="text/event-stream")
+
         async with httpx.AsyncClient(base_url=base_url) as client:
-            path = "/v1/chat/completions"
-            if payload.stream:
-                resp = await client.post(  # type: ignore[call-arg]
-                    path, json=payload.dict(), headers=headers, stream=True
-                )
-                try:
-                    resp.raise_for_status()
-                except httpx.HTTPError as exc:  # coverage: ignore
-                    raise HTTPException(
-                        status_code=502, detail="External provider error"
-                    ) from exc
-                return StreamingResponse(
-                    stream_resp(resp), media_type="text/event-stream"
-                )
             resp = await client.post(path, json=payload.dict(), headers=headers)
             try:
                 resp.raise_for_status()

--- a/tests/router/test_api.py
+++ b/tests/router/test_api.py
@@ -14,12 +14,12 @@ def test_chat_completions_dummy_response(tmp_path, monkeypatch) -> None:
     registry.create_tables()
     router_main.load_registry()
 
-    client = TestClient(router_main.app)
-    payload = {
-        "model": "dummy",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
-    response = client.post("/v1/chat/completions", json=payload)
-    assert response.status_code == 200
-    data = response.json()
-    assert data["choices"][0]["message"]["content"] == "Hello world"
+    with TestClient(router_main.app) as client:
+        payload = {
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["choices"][0]["message"]["content"] == "Hello world"

--- a/tests/router/test_external_proxy.py
+++ b/tests/router/test_external_proxy.py
@@ -50,11 +50,11 @@ def test_forward_to_openai(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
 
-    client = TestClient(router_main.app)
-    payload = {
-        "model": "gpt-3.5-turbo",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
-    response = client.post("/v1/chat/completions", json=payload)
-    assert response.status_code == 200
-    assert response.json()["choices"][0]["message"]["content"] == "OpenAI: hi"
+    with TestClient(router_main.app) as client:
+        payload = {
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["content"] == "OpenAI: hi"

--- a/tests/router/test_llmd_forward.py
+++ b/tests/router/test_llmd_forward.py
@@ -51,11 +51,11 @@ def test_forward_to_llmd(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
 
-    client = TestClient(router_main.app)
-    payload = {
-        "model": "cluster-model",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
-    response = client.post("/v1/chat/completions", json=payload)
-    assert response.status_code == 200
-    assert response.json()["choices"][0]["message"]["content"] == "llm-d: hi"
+    with TestClient(router_main.app) as client:
+        payload = {
+            "model": "cluster-model",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["content"] == "llm-d: hi"

--- a/tests/router/test_local_forward.py
+++ b/tests/router/test_local_forward.py
@@ -29,11 +29,11 @@ def test_forward_to_local_agent(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
 
-    client = TestClient(router_main.app)
-    payload = {
-        "model": "local_mistral",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
-    response = client.post("/v1/chat/completions", json=payload)
-    assert response.status_code == 200
-    assert response.json()["choices"][0]["message"]["content"] == "Echo: hi"
+    with TestClient(router_main.app) as client:
+        payload = {
+            "model": "local_mistral",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["content"] == "Echo: hi"

--- a/tests/router/test_metrics.py
+++ b/tests/router/test_metrics.py
@@ -5,21 +5,23 @@ import router.main as router_main
 
 
 def test_request_counter_increments() -> None:
-    client = TestClient(router_main.app)
-    before = (
-        REGISTRY.get_sample_value("router_requests_total", {"backend": "dummy"}) or 0
-    )
-    payload = {"model": "dummy", "messages": [{"role": "user", "content": "hi"}]}
-    resp = client.post("/v1/chat/completions", json=payload)
-    assert resp.status_code == 200
-    after = (
-        REGISTRY.get_sample_value("router_requests_total", {"backend": "dummy"}) or 0
-    )
-    assert after == before + 1
+    with TestClient(router_main.app) as client:
+        before = (
+            REGISTRY.get_sample_value("router_requests_total", {"backend": "dummy"})
+            or 0
+        )
+        payload = {"model": "dummy", "messages": [{"role": "user", "content": "hi"}]}
+        resp = client.post("/v1/chat/completions", json=payload)
+        assert resp.status_code == 200
+        after = (
+            REGISTRY.get_sample_value("router_requests_total", {"backend": "dummy"})
+            or 0
+        )
+        assert after == before + 1
 
 
 def test_metrics_endpoint() -> None:
-    client = TestClient(router_main.app)
-    resp = client.get("/metrics")
-    assert resp.status_code == 200
-    assert "router_requests_total" in resp.text
+    with TestClient(router_main.app) as client:
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        assert "router_requests_total" in resp.text

--- a/tests/router/test_provider_anthropic.py
+++ b/tests/router/test_provider_anthropic.py
@@ -50,11 +50,11 @@ def test_forward_to_anthropic(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
 
-    client = TestClient(router_main.app)
-    payload = {
-        "model": "claude-3",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
-    response = client.post("/v1/chat/completions", json=payload)
-    assert response.status_code == 200
-    assert response.json()["choices"][0]["message"]["content"] == "Anthropic: hi"
+    with TestClient(router_main.app) as client:
+        payload = {
+            "model": "claude-3",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["content"] == "Anthropic: hi"

--- a/tests/router/test_provider_google.py
+++ b/tests/router/test_provider_google.py
@@ -51,11 +51,11 @@ def test_forward_to_google(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
 
-    client = TestClient(router_main.app)
-    payload = {
-        "model": "gemini-pro",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
-    response = client.post("/v1/chat/completions", json=payload)
-    assert response.status_code == 200
-    assert response.json()["choices"][0]["message"]["content"] == "Google: hi"
+    with TestClient(router_main.app) as client:
+        payload = {
+            "model": "gemini-pro",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["content"] == "Google: hi"

--- a/tests/router/test_provider_openrouter.py
+++ b/tests/router/test_provider_openrouter.py
@@ -54,11 +54,11 @@ def test_forward_to_openrouter(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
 
-    client = TestClient(router_main.app)
-    payload = {
-        "model": "orc-1",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
-    response = client.post("/v1/chat/completions", json=payload)
-    assert response.status_code == 200
-    assert response.json()["choices"][0]["message"]["content"] == "OpenRouter: hi"
+    with TestClient(router_main.app) as client:
+        payload = {
+            "model": "orc-1",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["content"] == "OpenRouter: hi"

--- a/tests/router/test_provider_venice.py
+++ b/tests/router/test_provider_venice.py
@@ -50,11 +50,11 @@ def test_forward_to_venice(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr(router_main.httpx, "AsyncClient", client_factory)
 
-    client = TestClient(router_main.app)
-    payload = {
-        "model": "venus-1",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
-    response = client.post("/v1/chat/completions", json=payload)
-    assert response.status_code == 200
-    assert response.json()["choices"][0]["message"]["content"] == "Venice: hi"
+    with TestClient(router_main.app) as client:
+        payload = {
+            "model": "venus-1",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        response = client.post("/v1/chat/completions", json=payload)
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["content"] == "Venice: hi"

--- a/tests/router/test_rate_limit.py
+++ b/tests/router/test_rate_limit.py
@@ -6,10 +6,10 @@ def test_rate_limit(monkeypatch):
     monkeypatch.setattr(router_main, "RATE_LIMIT_REQUESTS", 2)
     monkeypatch.setattr(router_main, "RATE_LIMIT_WINDOW", 60)
     router_main.RATE_LIMIT_STATE.clear()
-    client = TestClient(router_main.app)
-    payload = {"model": "dummy", "messages": [{"role": "user", "content": "hi"}]}
-    assert client.post("/v1/chat/completions", json=payload).status_code == 200
-    assert client.post("/v1/chat/completions", json=payload).status_code == 200
-    resp = client.post("/v1/chat/completions", json=payload)
-    assert resp.status_code == 429
-    assert resp.json()["detail"] == "Rate limit exceeded"
+    with TestClient(router_main.app) as client:
+        payload = {"model": "dummy", "messages": [{"role": "user", "content": "hi"}]}
+        assert client.post("/v1/chat/completions", json=payload).status_code == 200
+        assert client.post("/v1/chat/completions", json=payload).status_code == 200
+        resp = client.post("/v1/chat/completions", json=payload)
+        assert resp.status_code == 429
+        assert resp.json()["detail"] == "Rate limit exceeded"

--- a/tests/router/test_weight_provider_router.py
+++ b/tests/router/test_weight_provider_router.py
@@ -30,8 +30,11 @@ def test_forward_to_weight_provider(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(provider, "_get_pipeline", lambda m: DummyPipe())
     router_main.WEIGHT_PROVIDERS.clear()
     router_main.WEIGHT_PROVIDERS["huggingface"] = provider
-    client = TestClient(router_main.app)
-    payload = {"model": "hf-model", "messages": [{"role": "user", "content": "hi"}]}
-    resp = client.post("/v1/chat/completions", json=payload)
-    assert resp.status_code == 200
-    assert resp.json()["choices"][0]["message"]["content"] == "HF: hi"
+    with TestClient(router_main.app) as client:
+        payload = {
+            "model": "hf-model",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        resp = client.post("/v1/chat/completions", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["choices"][0]["message"]["content"] == "HF: hi"


### PR DESCRIPTION
## Summary
- reload streaming providers for httpx>=0.28 using `client.stream`
- close TestClient between tests to avoid state bleed
- update CHANGELOG

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_683c9646ef0c83308dce0bddd23d2821