### PR TITLE
Add list-models CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Unified provider architecture for API and weight-based providers
 - Example Hugging Face env vars in `.env.example`
 - Updated provider streaming logic for HTTPX 0.28 and closed TestClient sessions in tests
+- CLI command `list-models` to display registry entries
 
 
 

--- a/docs/router_api.md
+++ b/docs/router_api.md
@@ -158,6 +158,15 @@ python -m router.cli add-model meta-llama/Llama-3 huggingface https://huggingfac
 Valid model types are `local`, `openai`, `llm-d`, `anthropic`, `google`,
 `openrouter`, `grok`, and `venice`.
 
+#### Listing Registered Models
+
+Show all entries in the model registry:
+
+```bash
+python -m router.cli list-models
+```
+
+
 ### Agent Registration & Heartbeats
 
 Agents announce themselves to the router using the `/register` and `/heartbeat`

--- a/router/cli.py
+++ b/router/cli.py
@@ -12,6 +12,7 @@ from .registry import (
     run_migrations,
     get_session,
     upsert_model,
+    list_models,
     clear_models,
     VALID_MODEL_TYPES,
 )
@@ -62,6 +63,17 @@ def add_model(name: str, type: str, endpoint: str, kind: str = "api") -> None:
 
     with get_session() as session:
         upsert_model(session, name, type, endpoint, kind)
+
+
+@app.command("list-models")
+def list_models_cmd() -> None:
+    """Print all registered models."""
+
+    with get_session() as session:
+        models = list_models(session)
+
+    for item in models:
+        typer.echo(f"{item.name}\t{item.type}\t{item.endpoint}\t{item.kind}")
 
 
 @app.command("refresh-openai")

--- a/tests/router/test_cli_misc.py
+++ b/tests/router/test_cli_misc.py
@@ -66,3 +66,23 @@ def test_add_model_invalid_type(monkeypatch):
     runner = CliRunner()
     result = runner.invoke(cli.app, ["add-model", "foo", "invalid", "http://x"])
     assert result.exit_code != 0
+
+
+def test_list_models(monkeypatch):
+    class Model:
+        def __init__(self, name, type, endpoint, kind):
+            self.name = name
+            self.type = type
+            self.endpoint = endpoint
+            self.kind = kind
+
+    def fake_list_models(session):
+        return [Model("foo", "local", "http://x", "weight")]
+
+    monkeypatch.setattr(cli, "get_session", lambda: DummySession())
+    monkeypatch.setattr(cli, "list_models", fake_list_models)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["list-models"])
+    assert result.exit_code == 0
+    assert "foo\tlocal\thttp://x\tweight" in result.stdout


### PR DESCRIPTION
## Summary
- add `list-models` admin CLI command
- document the new command in router API docs
- record changelog entry
- test CLI listing behavior

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_683ca1d932208330885b0f406c49aef2