### PR TITLE
Improve coverage for local agent utilities

### DIFF
--- a/tests/local_agent/test_heartbeat.py
+++ b/tests/local_agent/test_heartbeat.py
@@ -1,0 +1,25 @@
+import asyncio
+import pytest
+import local_agent.main as agent
+
+
+async def dummy_post(path: str, payload: dict) -> None:
+    dummy_post.calls.append((path, payload))
+    if len(dummy_post.calls) >= 2:
+        raise asyncio.CancelledError()
+
+
+dummy_post.calls = []
+
+
+def test_heartbeat_loop(monkeypatch):
+    monkeypatch.setattr(agent, "_post_with_retry", dummy_post)
+    monkeypatch.setattr(agent, "HEARTBEAT_INTERVAL", 0)
+    original_sleep = asyncio.sleep
+    monkeypatch.setattr(agent.asyncio, "sleep", lambda s: original_sleep(0))
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(agent.heartbeat_loop())
+
+    assert dummy_post.calls[0] == ("/heartbeat", {"name": agent.AGENT_NAME})
+    assert len(dummy_post.calls) >= 2

--- a/tests/local_agent/test_post_with_retry.py
+++ b/tests/local_agent/test_post_with_retry.py
@@ -1,0 +1,31 @@
+import asyncio
+import httpx
+import local_agent.main as agent
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __aenter__(self) -> "DummyClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        pass
+
+    async def post(self, url: str, json: dict) -> httpx.Response:
+        self.calls += 1
+        if self.calls == 1:
+            raise httpx.RequestError("unavailable", request=httpx.Request("POST", url))
+        return httpx.Response(200, request=httpx.Request("POST", url))
+
+
+def test_post_with_retry(monkeypatch) -> None:
+    client = DummyClient()
+    monkeypatch.setattr(agent.httpx, "AsyncClient", lambda *a, **kw: client)
+    original_sleep = asyncio.sleep
+    monkeypatch.setattr(agent.asyncio, "sleep", lambda s: original_sleep(0))
+
+    asyncio.run(agent._post_with_retry("/foo", {"x": 1}))
+
+    assert client.calls == 2


### PR DESCRIPTION
## Summary
- add tests for heartbeat loop and internal retry logic

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_683d7e1867e88330a40b38e7a814cc75