### PR TITLE
feat: add dynamic provider registry

### DIFF
--- a/router/main.py
+++ b/router/main.py
@@ -160,13 +160,12 @@ def get_weight_provider(name: str) -> WeightProvider:
 
     provider = WEIGHT_PROVIDERS.get(name)
     if provider is None:
-        try:
-            module = getattr(providers, name)
-        except AttributeError as exc:  # coverage: ignore -- defensive
+        module = providers.PROVIDER_REGISTRY.get(name)
+        if module is None:
             raise HTTPException(
                 status_code=500,
                 detail=f"Unsupported provider '{name}'",
-            ) from exc
+            )
         class_name = "".join(part.capitalize() for part in name.split("_")) + "Provider"
         provider_cls = getattr(module, class_name, None)
         if provider_cls is None:

--- a/router/providers/__init__.py
+++ b/router/providers/__init__.py
@@ -1,11 +1,37 @@
 """Collection of provider implementations for external APIs."""
 
-from . import anthropic, google, openrouter, grok, venice, openai, huggingface
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+from types import ModuleType
+
 from .base import ApiProvider, WeightProvider
+
+PROVIDER_REGISTRY: dict[str, ModuleType] = {}
+
+
+def register_provider(name: str, module: ModuleType) -> None:
+    """Register ``module`` under ``name``."""
+
+    PROVIDER_REGISTRY[name] = module
+
+
+from . import (
+    anthropic,
+    google,
+    openrouter,
+    grok,
+    venice,
+    openai,
+    huggingface,
+)  # noqa: E402
 
 __all__ = [
     "ApiProvider",
     "WeightProvider",
+    "PROVIDER_REGISTRY",
+    "register_provider",
     "anthropic",
     "google",
     "openrouter",

--- a/router/providers/anthropic.py
+++ b/router/providers/anthropic.py
@@ -10,6 +10,8 @@ from ..schemas import ChatCompletionRequest
 from typing import AsyncIterator
 
 from .base import ApiProvider
+from . import register_provider
+import sys
 
 
 class AnthropicProvider(ApiProvider):
@@ -57,3 +59,6 @@ async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | 
     """Backward compatible wrapper for ``AnthropicProvider``."""
     provider = AnthropicProvider()
     return await provider.forward(payload, base_url, api_key)
+
+
+register_provider("anthropic", sys.modules[__name__])

--- a/router/providers/google.py
+++ b/router/providers/google.py
@@ -10,6 +10,8 @@ from ..schemas import ChatCompletionRequest
 from typing import AsyncIterator
 
 from .base import ApiProvider
+from . import register_provider
+import sys
 
 
 class GoogleProvider(ApiProvider):
@@ -61,3 +63,6 @@ async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | 
     """Backward compatible wrapper for ``GoogleProvider``."""
     provider = GoogleProvider()
     return await provider.forward(payload, base_url, api_key)
+
+
+register_provider("google", sys.modules[__name__])

--- a/router/providers/grok.py
+++ b/router/providers/grok.py
@@ -10,6 +10,8 @@ from ..schemas import ChatCompletionRequest
 from typing import AsyncIterator
 
 from .base import ApiProvider
+from . import register_provider
+import sys
 
 
 class GrokProvider(ApiProvider):
@@ -57,3 +59,6 @@ async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | 
     """Backward compatible wrapper for ``GrokProvider``."""
     provider = GrokProvider()
     return await provider.forward(payload, base_url, api_key)
+
+
+register_provider("grok", sys.modules[__name__])

--- a/router/providers/huggingface.py
+++ b/router/providers/huggingface.py
@@ -13,6 +13,8 @@ from transformers import pipeline
 
 from ..schemas import ChatCompletionRequest
 from .base import WeightProvider
+from . import register_provider
+import sys
 
 
 class HuggingFaceProvider(WeightProvider):
@@ -82,3 +84,6 @@ async def forward(payload: ChatCompletionRequest, base_url: str) -> dict:
 
     provider = HuggingFaceProvider()
     return await provider.forward(payload, base_url)
+
+
+register_provider("huggingface", sys.modules[__name__])

--- a/router/providers/openai.py
+++ b/router/providers/openai.py
@@ -9,6 +9,8 @@ from fastapi.responses import StreamingResponse
 from ..schemas import ChatCompletionRequest
 from ..utils import stream_resp
 from .base import ApiProvider
+from . import register_provider
+import sys
 
 
 class OpenAIProvider(ApiProvider):
@@ -52,3 +54,6 @@ async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | 
     """Backward compatible wrapper for ``OpenAIProvider``."""
     provider = OpenAIProvider()
     return await provider.forward(payload, base_url, api_key)
+
+
+register_provider("openai", sys.modules[__name__])

--- a/router/providers/openrouter.py
+++ b/router/providers/openrouter.py
@@ -10,6 +10,8 @@ from ..schemas import ChatCompletionRequest
 from typing import AsyncIterator
 
 from .base import ApiProvider
+from . import register_provider
+import sys
 
 
 class OpenRouterProvider(ApiProvider):
@@ -57,3 +59,6 @@ async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | 
     """Backward compatible wrapper for ``OpenRouterProvider``."""
     provider = OpenRouterProvider()
     return await provider.forward(payload, base_url, api_key)
+
+
+register_provider("openrouter", sys.modules[__name__])

--- a/router/providers/venice.py
+++ b/router/providers/venice.py
@@ -10,6 +10,8 @@ from ..schemas import ChatCompletionRequest
 from typing import AsyncIterator
 
 from .base import ApiProvider
+from . import register_provider
+import sys
 
 
 class VeniceProvider(ApiProvider):
@@ -57,3 +59,6 @@ async def forward(payload: ChatCompletionRequest, base_url: str, api_key: str | 
     """Backward compatible wrapper for ``VeniceProvider``."""
     provider = VeniceProvider()
     return await provider.forward(payload, base_url, api_key)
+
+
+register_provider("venice", sys.modules[__name__])

--- a/tests/router/test_utils.py
+++ b/tests/router/test_utils.py
@@ -52,13 +52,20 @@ def test_get_weight_provider(monkeypatch):
             return {}
 
     dummy_module = types.SimpleNamespace(DummyProvider=Dummy)
-    monkeypatch.setattr(router_main.providers, "dummy", dummy_module, raising=False)
+    monkeypatch.setitem(router_main.providers.PROVIDER_REGISTRY, "dummy", dummy_module)
 
     router_main.WEIGHT_PROVIDERS.clear()
     provider1 = router_main.get_weight_provider("dummy")
     provider2 = router_main.get_weight_provider("dummy")
     assert isinstance(provider1, Dummy)
     assert provider1 is provider2
+    assert router_main.providers.PROVIDER_REGISTRY["dummy"] is dummy_module
 
     with pytest.raises(router_main.HTTPException):
         router_main.get_weight_provider("missing")
+
+
+def test_provider_registry_contains_defaults():
+    reg = router_main.providers.PROVIDER_REGISTRY
+    assert "openai" in reg
+    assert reg["openai"] is router_main.providers.openai


### PR DESCRIPTION
## Summary
- introduce `PROVIDER_REGISTRY` and `register_provider`
- update providers to self-register
- lookup weight providers using the registry
- verify registry behaviour in tests

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68483d97296883309b2900ab186ae63a