### PR TITLE
Add CLI monitoring commands

### DIFF
--- a/docs/router_api.md
+++ b/docs/router_api.md
@@ -222,3 +222,17 @@ The router exposes Prometheus metrics at `/metrics`. Basic counters
 track request volume, latency and cache hits. Logs are written to
 `logs/router.log` and rotated daily. Configure the log level via the
 `LOG_LEVEL` environment variable.
+
+Tail the log file using the CLI:
+
+```bash
+python -m router.cli show-logs --no-follow
+```
+
+Use `--follow` to stream updates or pass a custom path.
+
+Export metrics in Prometheus format:
+
+```bash
+python -m router.cli export-metrics
+```

--- a/tests/router/test_cli_logs_metrics.py
+++ b/tests/router/test_cli_logs_metrics.py
@@ -1,0 +1,26 @@
+from typer.testing import CliRunner
+import router.cli as cli
+
+
+def test_show_logs(tmp_path):
+    log_file = tmp_path / "router.log"
+    log_file.write_text("line1\nline2\n")
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["show-logs", str(log_file), "--no-follow"])
+    assert result.exit_code == 0
+    assert "line1" in result.stdout
+    assert "line2" in result.stdout
+
+
+def test_export_metrics(monkeypatch):
+    class Resp:
+        text = "router_requests_total 1"
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(cli.httpx, "get", lambda url, timeout=10: Resp())
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["export-metrics"])
+    assert result.exit_code == 0
+    assert "router_requests_total" in result.stdout


### PR DESCRIPTION
## Summary
- add `show-logs` and `export-metrics` to router CLI
- document CLI monitoring commands
- test `show-logs` and `export-metrics`

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68483d9a1d2c83308be7a9a34eaf9b27